### PR TITLE
fix to use glog at datastore initialization.

### DIFF
--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -21,7 +21,8 @@
 
 #include <limestone/api/datastore.h>
 #include "log_entry.h"
-#include <iostream>  // FIXME
+
+#include "glog/logging.h"
 
 namespace limestone::api {
 
@@ -34,7 +35,7 @@ datastore::datastore(configuration const& conf) {
     if (!result_check || error) {
         const bool result_mkdir = boost::filesystem::create_directory(location_, error);
         if (!result_mkdir || error) {
-            std::cerr << "fail to create directory" << std::endl;  // FIXME use logger
+            LOG(ERROR) << "fail to create directory: result_mkdir: " << result_mkdir << ", error_code: " << error << ", path: " << location_;
             std::abort();
         }
     }


### PR DESCRIPTION
データストア初期化部にロガーを使うよう FIXME がありましたので、修正を加えておきました。
背景として、 shirakami - limestone の結合テストでエラーの詳細を知りたいことがありました。