### PR TITLE
glog 出力部分のロケーションプレフィックス対応

### DIFF
--- a/include/limestone/logging.h
+++ b/include/limestone/logging.h
@@ -15,9 +15,7 @@
  */
 #pragma once
 
-#include <array>
 #include <cstdint>
-#include <string_view>
 
 namespace limestone {
 
@@ -45,97 +43,5 @@ static constexpr std::int32_t log_debug = 40;
  * @brief logging level constant for traces
  */
 static constexpr std::int32_t log_trace = 50;
-
-constexpr std::string_view find_fullname(std::string_view prettyname, std::string_view funcname) {
-    // search (funcname + "(")
-    size_t fn_pos = 0;  // head of function name
-    while ((fn_pos = prettyname.find(funcname, fn_pos)) != std::string_view::npos) {
-        if (prettyname[fn_pos + funcname.size()] == '(') {
-            break;  // found
-        }
-        fn_pos++;
-    }
-    if (fn_pos == std::string_view::npos) {
-        return funcname;  // fallback
-    }
-    // search to left, but skip <...>
-    size_t start_pos = std::string_view::npos;
-    int tv_nest = 0;  // "<...>" nest level
-    for (int i = fn_pos; i >= 0; i--) {
-        switch (prettyname[i]) {
-            case '>': tv_nest++; continue;
-            case '<': tv_nest--; continue;
-            case ' ': if (tv_nest <= 0) start_pos = i+1; break;
-        }
-        if (start_pos != std::string_view::npos) {
-            break;
-        }
-    }
-    if (start_pos == std::string_view::npos) {  // no return type, such as constructors
-        start_pos = 0;
-    }
-    return std::string_view(prettyname.data() + start_pos, fn_pos + funcname.length() - start_pos);
-}
-
-template<size_t N>
-constexpr auto location_prefix(const std::string_view sv) {
-    std::array<char, N + 3> buf{};
-
-    // tsurugi logging location prefix:
-    // * "::" -> ":"
-    // * "<...>" -> ""
-    // * [-A-Za-z0-9_:] only
-    int p = 0;
-    buf.at(p++) = '/';
-    buf.at(p++) = ':';
-    int tv_nest = 0;  // "<...>" nest level
-    for (size_t i = 0; i < sv.size(); i++) {
-        if (sv[i] == '<') {
-            tv_nest++;
-        } else if (sv[i] == '>') {
-            tv_nest--;
-        } else {
-            if (tv_nest <= 0) {
-                if (sv[i] == ':' && sv[i + 1] == ':') {
-                    buf.at(p++) = ':';
-                    i++;  // skip second colon
-                } else {
-                    buf.at(p++) = sv[i];
-                }
-            }
-        }
-    }
-    buf.at(p++) = ' ';
-    buf.at(p) = 0;
-    return buf;
-}
-
-template<size_t N, size_t M>
-constexpr auto location_prefix(const char (&prettyname)[N], const char (&funcname)[M]) {  // NOLINT
-    const std::string_view sv = find_fullname(prettyname, funcname);  // NOLINT
-    return location_prefix<std::max(N, M)>(sv);
-}
-
-// To force compile-time evaluation of constexpr location_prefix in C++17,
-// the result is once stored to the temporary constexpr variable.
-
-// NOTE: restriction of this implementation
-// side effect: If used in the form:
-//    if (cond) LOG_LP(ERROR) << "message";
-// your C++ compiler may warn that this statement contains dangling-else.
-//
-// workaround: rewrite like:
-//    if (cond) { LOG_LP(ERROR) << "message"; }
-
-// N.B. use consteval in C++20
-
-// NOLINTNEXTLINE
-#define _LOCATION_PREFIX_TO_STREAM(stream)  if (constexpr auto __tmplp = location_prefix(__PRETTY_FUNCTION__, __FUNCTION__); false) {} else stream << __tmplp.data()
-// NOLINTNEXTLINE
-#define LOG_LP(x)   _LOCATION_PREFIX_TO_STREAM(LOG(x))
-// NOLINTNEXTLINE
-#define VLOG_LP(x)  _LOCATION_PREFIX_TO_STREAM(VLOG(x))
-// NOLINTNEXTLINE
-#define DVLOG_LP(x) _LOCATION_PREFIX_TO_STREAM(DVLOG(x))
 
 } // namespace

--- a/src/limestone/cursor.cpp
+++ b/src/limestone/cursor.cpp
@@ -17,6 +17,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include "log_entry.h"
 

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -22,6 +22,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include <limestone/api/datastore.h>
 #include "log_entry.h"

--- a/src/limestone/datastore_restore.cpp
+++ b/src/limestone/datastore_restore.cpp
@@ -18,6 +18,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include <limestone/api/datastore.h>
 #include <limestone/status.h>

--- a/src/limestone/datastore_snapshot.cpp
+++ b/src/limestone/datastore_snapshot.cpp
@@ -19,6 +19,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include <limestone/api/datastore.h>
 #include "log_entry.h"

--- a/src/limestone/log_channel.cpp
+++ b/src/limestone/log_channel.cpp
@@ -18,6 +18,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include <limestone/api/log_channel.h>
 

--- a/src/limestone/logging_helper.h
+++ b/src/limestone/logging_helper.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023-2023 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <string_view>
+
+namespace limestone {
+
+constexpr std::string_view find_fullname(std::string_view prettyname, std::string_view funcname) {
+    // search (funcname + "(")
+    size_t fn_pos = 0;  // head of function name
+    while ((fn_pos = prettyname.find(funcname, fn_pos)) != std::string_view::npos) {
+        if (prettyname[fn_pos + funcname.size()] == '(') {
+            break;  // found
+        }
+        fn_pos++;
+    }
+    if (fn_pos == std::string_view::npos) {
+        return funcname;  // fallback
+    }
+    // search to left, but skip <...>
+    size_t start_pos = std::string_view::npos;
+    int tv_nest = 0;  // "<...>" nest level
+    for (int i = fn_pos; i >= 0; i--) {
+        switch (prettyname[i]) {
+            case '>': tv_nest++; continue;
+            case '<': tv_nest--; continue;
+            case ' ': if (tv_nest <= 0) start_pos = i+1; break;
+        }
+        if (start_pos != std::string_view::npos) {
+            break;
+        }
+    }
+    if (start_pos == std::string_view::npos) {  // no return type, such as constructors
+        start_pos = 0;
+    }
+    return std::string_view(prettyname.data() + start_pos, fn_pos + funcname.length() - start_pos);
+}
+
+template<size_t N>
+constexpr auto location_prefix(const std::string_view sv) {
+    std::array<char, N + 3> buf{};
+
+    // tsurugi logging location prefix:
+    // * "::" -> ":"
+    // * "<...>" -> ""
+    // * [-A-Za-z0-9_:] only
+    int p = 0;
+    buf.at(p++) = '/';
+    buf.at(p++) = ':';
+    int tv_nest = 0;  // "<...>" nest level
+    for (size_t i = 0; i < sv.size(); i++) {
+        if (sv[i] == '<') {
+            tv_nest++;
+        } else if (sv[i] == '>') {
+            tv_nest--;
+        } else {
+            if (tv_nest <= 0) {
+                if (sv[i] == ':' && sv[i + 1] == ':') {
+                    buf.at(p++) = ':';
+                    i++;  // skip second colon
+                } else {
+                    buf.at(p++) = sv[i];
+                }
+            }
+        }
+    }
+    buf.at(p++) = ' ';
+    buf.at(p) = 0;
+    return buf;
+}
+
+template<size_t N, size_t M>
+constexpr auto location_prefix(const char (&prettyname)[N], const char (&funcname)[M]) {  // NOLINT
+    const std::string_view sv = find_fullname(prettyname, funcname);  // NOLINT
+    return location_prefix<std::max(N, M)>(sv);
+}
+
+// To force compile-time evaluation of constexpr location_prefix in C++17,
+// the result is once stored to the temporary constexpr variable.
+
+// NOTE: restriction of this implementation
+// side effect: If used in the form:
+//    if (cond) LOG_LP(ERROR) << "message";
+// your C++ compiler may warn that this statement contains dangling-else.
+//
+// workaround: rewrite like:
+//    if (cond) { LOG_LP(ERROR) << "message"; }
+
+// N.B. use consteval in C++20
+
+// NOLINTNEXTLINE
+#define _LOCATION_PREFIX_TO_STREAM(stream)  if (constexpr auto __tmplp = location_prefix(__PRETTY_FUNCTION__, __FUNCTION__); false) {} else stream << __tmplp.data()
+// NOLINTNEXTLINE
+#define LOG_LP(x)   _LOCATION_PREFIX_TO_STREAM(LOG(x))
+// NOLINTNEXTLINE
+#define VLOG_LP(x)  _LOCATION_PREFIX_TO_STREAM(VLOG(x))
+// NOLINTNEXTLINE
+#define DVLOG_LP(x) _LOCATION_PREFIX_TO_STREAM(DVLOG(x))
+
+} // namespace

--- a/src/limestone/snapshot.cpp
+++ b/src/limestone/snapshot.cpp
@@ -17,6 +17,7 @@
 
 #include <glog/logging.h>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include <boost/filesystem.hpp>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ file(GLOB SRCS
         "limestone/api/*.cpp"
         "limestone/log/*.cpp"
         "limestone/epoch/*.cpp"
+        "limestone/utils/*.cpp"
         )
 
 foreach(file ${SRCS})

--- a/test/limestone/utils/logging_helper_test.cpp
+++ b/test/limestone/utils/logging_helper_test.cpp
@@ -1,12 +1,13 @@
 
 #include <sstream>
 #include <limestone/logging.h>
+#include "logging_helper.h"
 
 #include "test_root.h"
 
 namespace limestone::testing {
 
-class logging_test : public ::testing::Test {
+class logging_helper_test : public ::testing::Test {
 public:
     void SetUp() {
     }
@@ -16,7 +17,7 @@ public:
 
 };
 
-TEST_F(logging_test, find_fullname) { // NOLINT
+TEST_F(logging_helper_test, find_fullname) { // NOLINT
     // check constexpr-ness (if fail, then compile error)
     constexpr std::string_view a = find_fullname(__PRETTY_FUNCTION__, __FUNCTION__);
 
@@ -31,7 +32,7 @@ TEST_F(logging_test, find_fullname) { // NOLINT
     // ASSERT_EQ(find_fullname("auto main(int, char **)::(anonymous class)::operator()()", "operator()"), ???);
 }
 
-TEST_F(logging_test, location_prefix_sv) { // NOLINT
+TEST_F(logging_helper_test, location_prefix_sv) { // NOLINT
     // check constexpr-ness (if fail, then compile error)
     constexpr auto a = location_prefix<2>(std::string_view("a"));
 
@@ -39,7 +40,7 @@ TEST_F(logging_test, location_prefix_sv) { // NOLINT
     ASSERT_EQ(std::string(location_prefix<50>("limestone::api::datastore::recover").data()), "/:limestone:api:datastore:recover ");
 }
 
-TEST_F(logging_test, location_prefix_constchar) { // NOLINT
+TEST_F(logging_helper_test, location_prefix_constchar) { // NOLINT
     // check constexpr-ness (if fail, then compile error)
     constexpr auto a = location_prefix(__PRETTY_FUNCTION__, __FUNCTION__);
 
@@ -54,36 +55,36 @@ TEST_F(logging_test, location_prefix_constchar) { // NOLINT
 
 #define LOG(_ignored) lbuf
 
-class logging_test_foo1 {
+class logging_helper_test_foo1 {
 public:
     int foo(int& p) {
         std::ostringstream lbuf;
         lbuf.str("");
         LOG_LP(0) << "TEST";
-        assert(lbuf.str() == "/:limestone:testing:logging_test_foo1:foo TEST");
+        assert(lbuf.str() == "/:limestone:testing:logging_helper_test_foo1:foo TEST");
         return 0;
     }
 };
 template<class T, int n>
-class logging_test_foo2 {
+class logging_helper_test_foo2 {
 public:
     T foo(int& p, int &p2) {
         std::ostringstream lbuf;
-        // limestone::logging_test_foo2<T, n>::foo
+        // limestone::logging_helper_test_foo2<T, n>::foo
         lbuf.str("");
         LOG_LP(0) << "TEST";
-        assert(lbuf.str() == "/:limestone:testing:logging_test_foo2:foo TEST");
+        assert(lbuf.str() == "/:limestone:testing:logging_helper_test_foo2:foo TEST");
         auto lambda1 = [&lbuf](int u){
-            // g++-9:      limestone::testing::logging_test_foo2<T, n>::foo<long unsigned int, 99>::<lambda(int)>
-            // clang++-11: auto limestone::testing::logging_test_foo2<unsigned long, 99>::foo(int &, int &)::(anonymous class)::operator()(int)
+            // g++-9:      limestone::testing::logging_helper_test_foo2<T, n>::foo<long unsigned int, 99>::<lambda(int)>
+            // clang++-11: auto limestone::testing::logging_helper_test_foo2<unsigned long, 99>::foo(int &, int &)::(anonymous class)::operator()(int)
             lbuf.str("");
             LOG_LP(0) << "TEST";
             //assert(lbuf.str() == ???);
         };
         lambda1(1);
         std::function<long double(int)> lambda2 = [&lbuf](int u){
-            // g++-9:      limestone::testing::logging_test_foo2<T, n>::foo<long unsigned int, 99>::<lambda(int)>
-            // clang++-11: auto limestone::testing::logging_test_foo2<unsigned long, 99>::foo(int &, int &)::(anonymous class)::operator()(int)
+            // g++-9:      limestone::testing::logging_helper_test_foo2<T, n>::foo<long unsigned int, 99>::<lambda(int)>
+            // clang++-11: auto limestone::testing::logging_helper_test_foo2<unsigned long, 99>::foo(int &, int &)::(anonymous class)::operator()(int)
             lbuf.str("");
             LOG_LP(0) << "TEST";
             //assert(lbuf.str() == ???);
@@ -95,11 +96,11 @@ public:
     long double operator() (const char *p) {
         std::ostringstream lbuf;
         LOG_LP(0) << "TEST";
-        assert(lbuf.str() == "/:limestone:testing:logging_test_foo2:operator() TEST");
+        assert(lbuf.str() == "/:limestone:testing:logging_helper_test_foo2:operator() TEST");
         auto lambda1 = [&lbuf](int u){
             //std::cout << "PF:" << __PRETTY_FUNCTION__ << " F:" << __FUNCTION__ << std::endl;
-            // g++-9:      limestone::testing::logging_test_foo2<T, n>::operator()(const char*) [with T = long unsigned int; int n = 99]::<lambda(int)>
-            // clang++-11: auto limestone::testing::logging_test_foo2<unsigned long, 99>::operator()(const char *)::(anonymous class)::operator()(int) const [T = unsigned long, n = 99]
+            // g++-9:      limestone::testing::logging_helper_test_foo2<T, n>::operator()(const char*) [with T = long unsigned int; int n = 99]::<lambda(int)>
+            // clang++-11: auto limestone::testing::logging_helper_test_foo2<unsigned long, 99>::operator()(const char *)::(anonymous class)::operator()(int) const [T = unsigned long, n = 99]
             lbuf.str("");
             LOG_LP(0) << "TEST";
             //assert(lbuf.str() == ???);
@@ -109,11 +110,11 @@ public:
     }
 };
 
-TEST_F(logging_test, assert_in_other_methods) { // NOLINT
+TEST_F(logging_helper_test, assert_in_other_methods) { // NOLINT
     int dummy = 1234;
-    logging_test_foo1 foo1;
+    logging_helper_test_foo1 foo1;
     foo1.foo(dummy);
-    logging_test_foo2<unsigned long, 99> foo2;
+    logging_helper_test_foo2<unsigned long, 99> foo2;
     foo2.foo(dummy, dummy);
     foo2("a");
 }


### PR DESCRIPTION
#21 の件ですが、一部機能が未対応ですが、あまり使われなさそうな割に、
対応に時間がかかりそうなので、一度ここまでにします。
(ブランチが増えてきたので整頓したいという理由もあります)

未対応機能(把握分):
* 演算子オーバーロード
    * キャスト含む
* クロージャ (lambda)