### PR TITLE
add logging at start/end of datastore::shutdown()

### DIFF
--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -177,8 +177,12 @@ void datastore::add_snapshot_callback(std::function<void(write_version_type)> ca
 }
 
 std::future<void> datastore::shutdown() noexcept {
+    VLOG_LP(log_info) << "start";
     state_ = state::shutdown;
-    return std::async(std::launch::async, []{ std::this_thread::sleep_for(std::chrono::microseconds(100000)); });
+    return std::async(std::launch::async, []{
+        std::this_thread::sleep_for(std::chrono::microseconds(100000));
+        VLOG(log_info) << "/:limestone:datastore:shutdown end";
+    });
 }
 
 // old interface


### PR DESCRIPTION
For project-tsurugi/tsurugi-issues#189.

どこをもって終了(end)とすべきなのかは検討の余地があると思いますが、この位置とします。
現状では、呼び出した shirakami がこの `future` を捨てるため、そこで wait するようです。