### PR TITLE
add INFO level log on receiving configuration values

### DIFF
--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -33,6 +33,7 @@ namespace limestone::api {
 datastore::datastore() noexcept = default;
 
 datastore::datastore(configuration const& conf) : location_(conf.data_locations_.at(0)) {
+    LOG(INFO) << "/limestone:config:datastore setting log location = " << location_.string();
     boost::system::error_code error;
     const bool result_check = boost::filesystem::exists(location_, error);
     if (!result_check || error) {
@@ -65,6 +66,7 @@ datastore::datastore(configuration const& conf) : location_(conf.data_locations_
     }
 
     recover_max_parallelism_ = conf.recover_max_parallelism_;
+    LOG(INFO) << "/limestone:config:datastore setting the number of recover process thread = " << recover_max_parallelism_;
 
     VLOG_LP(log_debug) << "datastore is created, location = " << location_.string();
 }


### PR DESCRIPTION
設定項目を消費するときに INFO レベルで受け取った値をログ出力するようにします。
案件: project-tsurugi/tsurugi-issues#365