### PR TITLE
change to throw exception on I/O error; including API change (drop noexcept)

### DIFF
--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -150,7 +150,7 @@ public:
      * @param new epoch id which must be greater than current epoch ID.
      * @attention this function should be called after the ready() is called.
      */
-    void switch_epoch(epoch_id_type epoch_id) noexcept;
+    void switch_epoch(epoch_id_type epoch_id);
 
     /**
      * @brief register a callback on successful persistence
@@ -265,7 +265,7 @@ private:
 
     epoch_id_type search_max_durable_epock_id() noexcept;
 
-    void update_min_epoch_id(bool from_switch_epoch = false) noexcept;
+    void update_min_epoch_id(bool from_switch_epoch = false);
     
     void check_after_ready(std::string_view func) const noexcept;
 
@@ -277,7 +277,7 @@ private:
      * @param from the location of log files
      * @attention this function is not thread-safe.
      */
-    void create_snapshot() noexcept;
+    void create_snapshot();
 
     epoch_id_type last_durable_epoch_in_dir() noexcept;
 

--- a/include/limestone/api/log_channel.h
+++ b/include/limestone/api/log_channel.h
@@ -49,7 +49,7 @@ public:
      * @attention this function is not thread-safe.
      * @note the current epoch is the last epoch specified by datastore::switch_epoch()
      */
-    void begin_session() noexcept;
+    void begin_session();
 
     /**
      * @brief notifies the completion of an operation in this channel for the current persistent session the channel is participating in
@@ -57,7 +57,7 @@ public:
      * @note when all channels that have participated in the current persistent session call end_session() and the current epoch is
      * greater than the session's epoch, the persistent session itself is complete
      */
-    void end_session() noexcept;
+    void end_session();
 
     /**
      * @brief terminate the current persistent session in which this channel is participating with an error
@@ -73,7 +73,7 @@ public:
      * @param write_version (optional) the write version of the entry to be added. If omitted, the default value is used
      * @attention this function is not thread-safe.
      */
-    void add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version) noexcept;
+    void add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version);
 
     /**
      * @brief adds an entry to the current persistent session
@@ -95,7 +95,7 @@ public:
      * @note no deletion operation is performed on the entry that has been added to the current persistent session, instead,
      * the entries to be deleted are treated as if they do not exist in a recover() operation from a log stored in the current persistent session
      */
-    void remove_entry(storage_id_type storage_id, std::string_view key, write_version_type write_version) noexcept;
+    void remove_entry(storage_id_type storage_id, std::string_view key, write_version_type write_version);
 
     /**
      * @brief add an entry indicating the addition of the specified storage

--- a/include/limestone/api/log_channel.h
+++ b/include/limestone/api/log_channel.h
@@ -84,7 +84,7 @@ public:
      * @param large_objects (optional) the list of large objects associated with the entry to be added
      * @attention this function is not thread-safe.
      */
-    void add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version, const std::vector<large_object_input>& large_objects) noexcept;
+    void add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version, const std::vector<large_object_input>& large_objects);
 
     /**
      * @brief add an entry indicating the deletion of entries
@@ -104,7 +104,7 @@ public:
      * @attention this function is not thread-safe.
      * @impl this operation may be ignored.
      */
-    void add_storage(storage_id_type storage_id, write_version_type write_version) noexcept;
+    void add_storage(storage_id_type storage_id, write_version_type write_version);
 
     /**
      * @brief add an entry indicating the deletion of the specified storage and all entries for that storage
@@ -114,7 +114,7 @@ public:
      * @note no deletion operation is performed on the entry that has been added to the current persistent session, instead,
      * the target entries are treated as if they do not exist in the recover() operation from the log stored in the current persistent session.
      */
-    void remove_storage(storage_id_type storage_id, write_version_type write_version) noexcept;
+    void remove_storage(storage_id_type storage_id, write_version_type write_version);
 
     /**
      * @brief add an entry indicating the deletion of all entries contained in the specified storage
@@ -124,7 +124,7 @@ public:
      * @note no deletion operation is performed on the entry that has been added to the current persistent session, instead,
      * the target entries are treated as if they do not exist in the recover() operation from the log stored in the current persistent session.
      */
-    void truncate_storage(storage_id_type storage_id, write_version_type write_version) noexcept;
+    void truncate_storage(storage_id_type storage_id, write_version_type write_version);
 
     /**
      * @brief this is for test purpose only, must not be used for any purpose other than testing

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -106,7 +106,7 @@ log_channel& datastore::create_channel(const boost::filesystem::path& location) 
 
 epoch_id_type datastore::last_epoch() const noexcept { return static_cast<epoch_id_type>(epoch_id_informed_.load()); }
 
-void datastore::switch_epoch(epoch_id_type new_epoch_id) noexcept {
+void datastore::switch_epoch(epoch_id_type new_epoch_id) {
     check_after_ready(static_cast<const char*>(__func__));
 
     auto neid = static_cast<std::uint64_t>(new_epoch_id);
@@ -118,7 +118,7 @@ void datastore::switch_epoch(epoch_id_type new_epoch_id) noexcept {
     update_min_epoch_id(true);
 }
 
-void datastore::update_min_epoch_id(bool from_switch_epoch) noexcept {  // NOLINT(readability-function-cognitive-complexity)
+void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readability-function-cognitive-complexity)
     auto upper_limit = epoch_id_switched_.load() - 1;
     epoch_id_type max_finished_epoch = 0;
 
@@ -149,20 +149,20 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) noexcept {  // NOLIN
             FILE* strm = fopen(epoch_file_path_.c_str(), "a");  // NOLINT(*-owning-memory)
             if (!strm) {
                 LOG_LP(ERROR) << "fopen failed, errno = " << errno;
-                std::abort();
+                throw std::runtime_error("I/O error");
             }
             log_entry::durable_epoch(strm, static_cast<epoch_id_type>(epoch_id_informed_.load()));
             if (fflush(strm) != 0) {
                 LOG_LP(ERROR) << "fflush failed, errno = " << errno;
-                std::abort();
+                throw std::runtime_error("I/O error");
             }
             if (fsync(fileno(strm)) != 0) {
                 LOG_LP(ERROR) << "fsync failed, errno = " << errno;
-                std::abort();
+                throw std::runtime_error("I/O error");
             }
             if (fclose(strm) != 0) {  // NOLINT(*-owning-memory)
                 LOG_LP(ERROR) << "fclose failed, errno = " << errno;
-                std::abort();
+                throw std::runtime_error("I/O error");
             }
             break;
         }

--- a/src/limestone/log_channel.cpp
+++ b/src/limestone/log_channel.cpp
@@ -85,9 +85,9 @@ void log_channel::add_entry(storage_id_type storage_id, std::string_view key, st
     write_version_ = write_version;
 }
 
-void log_channel::add_entry([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] std::string_view key, [[maybe_unused]] std::string_view value, [[maybe_unused]] write_version_type write_version, [[maybe_unused]] const std::vector<large_object_input>& large_objects) noexcept {
+void log_channel::add_entry([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] std::string_view key, [[maybe_unused]] std::string_view value, [[maybe_unused]] write_version_type write_version, [[maybe_unused]] const std::vector<large_object_input>& large_objects) {
     LOG_LP(ERROR) << "not implemented";
-    std::abort();  // FIXME
+    throw std::runtime_error("not implemented");  // FIXME
 };
 
 void log_channel::remove_entry(storage_id_type storage_id, std::string_view key, write_version_type write_version) {
@@ -95,19 +95,19 @@ void log_channel::remove_entry(storage_id_type storage_id, std::string_view key,
     write_version_ = write_version;
 }
 
-void log_channel::add_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) noexcept {
+void log_channel::add_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) {
     LOG_LP(ERROR) << "not implemented";
-    std::abort();  // FIXME
+    throw std::runtime_error("not implemented");  // FIXME
 }
 
-void log_channel::remove_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) noexcept {
+void log_channel::remove_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) {
     LOG_LP(ERROR) << "not implemented";
-    std::abort();  // FIXME
+    throw std::runtime_error("not implemented");  // FIXME
 }
 
-void log_channel::truncate_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) noexcept {
+void log_channel::truncate_storage([[maybe_unused]] storage_id_type storage_id, [[maybe_unused]] write_version_type write_version) {
     LOG_LP(ERROR) << "not implemented";
-    std::abort();  // FIXME
+    throw std::runtime_error("not implemented");  // FIXME
 }
 
 boost::filesystem::path log_channel::file_path() const noexcept {

--- a/src/limestone/log_channel.cpp
+++ b/src/limestone/log_channel.cpp
@@ -37,7 +37,7 @@ log_channel::log_channel(boost::filesystem::path location, std::size_t id, datas
     file_ = ss.str();
 }
 
-void log_channel::begin_session() noexcept {
+void log_channel::begin_session() {
     do {
         current_epoch_id_.store(envelope_.epoch_id_switched_.load());
         std::atomic_thread_fence(std::memory_order_acq_rel);
@@ -47,7 +47,7 @@ void log_channel::begin_session() noexcept {
     strm_ = fopen(log_file.c_str(), "a");  // NOLINT(*-owning-memory)
     if (!strm_) {
         LOG_LP(ERROR) << "I/O error, cannot make file on " <<  location_ << ", errno = " << errno;
-        std::abort();
+        throw std::runtime_error("I/O error");
     }
     setvbuf(strm_, nullptr, _IOFBF, 128L * 1024L);  // NOLINT, NB. glibc may ignore size when _IOFBF and buffer=NULL
     if (!registered_) {
@@ -57,21 +57,21 @@ void log_channel::begin_session() noexcept {
     log_entry::begin_session(strm_, static_cast<epoch_id_type>(current_epoch_id_.load()));
 }
 
-void log_channel::end_session() noexcept {
+void log_channel::end_session() {
     if (fflush(strm_) != 0) {
         LOG_LP(ERROR) << "fflush failed, errno = " << errno;
-        std::abort();
+        throw std::runtime_error("I/O error");
     }
     if (fsync(fileno(strm_)) != 0) {
         LOG_LP(ERROR) << "fsync failed, errno = " << errno;
-        std::abort();
+        throw std::runtime_error("I/O error");
     }
     finished_epoch_id_.store(current_epoch_id_.load());
     current_epoch_id_.store(UINT64_MAX);
     envelope_.update_min_epoch_id();
     if (fclose(strm_) != 0) {  // NOLINT(*-owning-memory)
         LOG_LP(ERROR) << "fclose failed, errno = " << errno;
-        std::abort();
+        throw std::runtime_error("I/O error");
     }
 }
 
@@ -80,7 +80,7 @@ void log_channel::abort_session([[maybe_unused]] status status_code, [[maybe_unu
     std::abort();  // FIXME
 }
 
-void log_channel::add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version) noexcept {
+void log_channel::add_entry(storage_id_type storage_id, std::string_view key, std::string_view value, write_version_type write_version) {
     log_entry::write(strm_, storage_id, key, value, write_version);
     write_version_ = write_version;
 }
@@ -90,7 +90,7 @@ void log_channel::add_entry([[maybe_unused]] storage_id_type storage_id, [[maybe
     std::abort();  // FIXME
 };
 
-void log_channel::remove_entry(storage_id_type storage_id, std::string_view key, write_version_type write_version) noexcept {
+void log_channel::remove_entry(storage_id_type storage_id, std::string_view key, write_version_type write_version) {
     log_entry::write_remove(strm_, storage_id, key, write_version);
     write_version_ = write_version;
 }

--- a/src/limestone/log_entry.h
+++ b/src/limestone/log_entry.h
@@ -243,7 +243,7 @@ private:
         int ret = fputc(value, out);
         if (ret == EOF) {
             LOG_LP(ERROR) << "fputc failed, errno = " << errno;
-            std::abort();
+            throw std::runtime_error("I/O error");
         }
     }
     static void write_uint32le(FILE* out, const std::uint32_t value) {
@@ -269,7 +269,7 @@ private:
         auto ret = fwrite(buf, len, 1, out);
         if (ret != 1) {
             LOG_LP(ERROR) << "fwrite failed, errno = " << errno;
-            std::abort();
+            throw std::runtime_error("I/O error");
         }
     }
 };


### PR DESCRIPTION
#42 では、ファイル書き込みに関するエラーを検出した際に、API 上でエラーを返す方法がないので、すべて `std::abort()` で落とすようにしましたが、
これを、API を変更して例外を投げるようにします。(`noexcept` を落とす)
entry を追加するメソッドの多くが unimplemented ですが、これらの API  も同様に変更します。

shirakami 側が `noexcept` を前提としたコーディングをしていないので、shirakami側のソースの変更なしでコンパイルが通ることを確認しました。

関連: project-tsurugi/tsurugi-issues#363