### PR TITLE
Handling incomplete logs and reject broken files

### DIFF
--- a/include/limestone/api/cursor.h
+++ b/include/limestone/api/cursor.h
@@ -49,7 +49,7 @@ public:
      * @attention this function is not thread-safe.
      * @return true if the next entry exists, false otherwise
      */
-    bool next() noexcept;
+    bool next();
 
     /**
      * @brief returns the storage ID of the entry at the current cursor position

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -279,7 +279,7 @@ private:
      */
     void create_snapshot();
 
-    epoch_id_type last_durable_epoch_in_dir() noexcept;
+    epoch_id_type last_durable_epoch_in_dir();
 
     /**
      * @brief requests the data store to rotate log files

--- a/src/limestone/cursor.cpp
+++ b/src/limestone/cursor.cpp
@@ -34,7 +34,7 @@ cursor::~cursor() noexcept {
     istrm_.close();
 }
 
-bool cursor::next() noexcept {
+bool cursor::next() {
     if (!istrm_.good()) {
         DVLOG_LP(log_trace) << "file stream of the cursor is not good";
         return false;

--- a/src/limestone/datastore_snapshot.cpp
+++ b/src/limestone/datastore_snapshot.cpp
@@ -55,7 +55,7 @@ using namespace limestone::internal;
 constexpr std::size_t write_version_size = sizeof(epoch_id_type) + sizeof(std::uint64_t);
 static_assert(write_version_size == 16);
 
-epoch_id_type datastore::last_durable_epoch_in_dir() noexcept {
+epoch_id_type datastore::last_durable_epoch_in_dir() {
     auto& from_dir = location_;
     // read main epoch file first
     std::optional<epoch_id_type> ld_epoch = last_durable_epoch(from_dir / std::string(epoch_file_name));

--- a/src/limestone/datastore_snapshot.cpp
+++ b/src/limestone/datastore_snapshot.cpp
@@ -39,6 +39,10 @@ std::optional<epoch_id_type> last_durable_epoch(const boost::filesystem::path& f
     log_entry e;
     istrm.open(file, std::ios_base::in | std::ios_base::binary);
     while (e.read(istrm)) {
+        if (e.type() != log_entry::entry_type::marker_durable) {
+            LOG_LP(ERROR) << "this epoch file is broken: unexpected log_entry type: " << static_cast<int>(e.type());
+            throw std::runtime_error("unexpected log_entry type for epoch file");
+        }
         if (!rv.has_value() || e.epoch_id() > rv) {
             rv = e.epoch_id();
         }

--- a/src/limestone/internal.h
+++ b/src/limestone/internal.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+
+#include <limestone/api/datastore.h>
+
+namespace limestone::internal {
+using namespace limestone::api;
+
+// return max epoch in file.
+std::optional<epoch_id_type> last_durable_epoch(const boost::filesystem::path& file);
+
+epoch_id_type scan_one_pwal_file(const boost::filesystem::path& pwal, epoch_id_type ld_epoch, const std::function<void(log_entry&)>& add_entry);
+
+}

--- a/src/limestone/log_entry.h
+++ b/src/limestone/log_entry.h
@@ -44,6 +44,7 @@ public:
         marker_end,
         marker_durable,
         remove_entry,
+        marker_invalidated_begin,
     };
     
     log_entry() = default;
@@ -60,6 +61,11 @@ public:
     }
     static void durable_epoch(FILE* strm, epoch_id_type epoch) {
         entry_type type = entry_type::marker_durable;
+        write_uint8(strm, static_cast<std::uint8_t>(type));
+        write_uint64le(strm, static_cast<std::uint64_t>(epoch));
+    }
+    static void invalidated_begin(FILE* strm, epoch_id_type epoch) {
+        entry_type type = entry_type::marker_invalidated_begin;
         write_uint8(strm, static_cast<std::uint8_t>(type));
         write_uint64le(strm, static_cast<std::uint64_t>(epoch));
     }
@@ -81,6 +87,9 @@ public:
             break;
         case entry_type::marker_durable:
             durable_epoch(strm, epoch_id_);
+            break;
+        case entry_type::marker_invalidated_begin:
+            invalidated_begin(strm, epoch_id_);
             break;
         case entry_type::this_id_is_not_used:
             break;
@@ -183,6 +192,7 @@ public:
         case entry_type::marker_begin:
         case entry_type::marker_end:
         case entry_type::marker_durable:
+        case entry_type::marker_invalidated_begin:
             epoch_id_ = static_cast<epoch_id_type>(read_uint64le(strm));
             break;
 

--- a/src/limestone/log_entry.h
+++ b/src/limestone/log_entry.h
@@ -160,7 +160,7 @@ public:
     }
 
 // for reader
-    bool read(boost::filesystem::ifstream& strm) {
+    bool read(std::istream& strm) {
         strm.read(&one_char_, sizeof(char));
         entry_type_ = static_cast<entry_type>(one_char_);        
         if (strm.eof()) {

--- a/src/limestone/log_entry.h
+++ b/src/limestone/log_entry.h
@@ -197,7 +197,9 @@ public:
             break;
 
         case entry_type::this_id_is_not_used:
-            return false;
+        default:
+            LOG_LP(ERROR) << "this log_entry is broken: unknown type: " << static_cast<int>(entry_type_);
+            throw std::runtime_error("unknown log_entry type");
         }
 
         return true;


### PR DESCRIPTION
WAL ファイルの取り扱いを頑強にする修正です
* コミット中のサーバクラッシュ等で不完全な状態になっている WAL エントリを無効化し取り込まないようにする
* pwal ファイルの log_entry が途中で切れている場合に検出しエラーとする
* epoch ファイルに durable epoch 記録以外のレコードがあった場合にエラーとする

案件: https://github.com/project-tsurugi/tsurugi-issues/issues/461 (症状4)
