### PR TITLE
introduce log dir format version and checking the version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ elseif(${RECOVERY_SORTER_KVSLIB_UPPERCASE} STREQUAL "LEVELDB")
 else()
     message(FATAL_ERROR "unsupported RECOVERY_SORTER_KVSLIB value: ${RECOVERY_SORTER_KVSLIB_UPPERCASE}")
 endif()
-      
+find_package(nlohmann_json 3.7.0 REQUIRED)
+
 add_subdirectory(third_party) # should be before enable_testing()
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ git submodule update --init --recursive
 ```dockerfile
 FROM ubuntu:22.04
 
-RUN apt update -y && apt install -y git build-essential cmake ninja-build libboost-filesystem-dev libboost-system-dev libboost-container-dev libboost-thread-dev libboost-stacktrace-dev libgoogle-glog-dev libgflags-dev doxygen libleveldb-dev librocksdb-dev pkg-config
+RUN apt update -y && apt install -y git build-essential cmake ninja-build libboost-filesystem-dev libboost-system-dev libboost-container-dev libboost-thread-dev libboost-stacktrace-dev libgoogle-glog-dev libgflags-dev doxygen libleveldb-dev librocksdb-dev pkg-config nlohmann-json3-dev
 # libleveldb-dev is not required if -DRECOVERY_SORTER_KVSLIB=ROCKSDB
 # librocksdb-dev is not required if -DRECOVERY_SORTER_KVSLIB=LEVELDB
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(${package_name}
         PRIVATE Boost::container
         PRIVATE glog::glog
         PRIVATE ${sort_lib}
+        PRIVATE nlohmann_json::nlohmann_json
 )
 
 set_compile_options(${package_name})
@@ -49,4 +50,5 @@ target_link_libraries(limestone-impl
         INTERFACE Boost::container
         INTERFACE glog::glog
         INTERFACE ${sort_lib}
+        INTERFACE nlohmann_json::nlohmann_json
 )

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -58,8 +58,6 @@ datastore::datastore(configuration const& conf) : location_(conf.data_locations_
         if (count == 0) {
             internal::setup_initial_logdir(location_);
             add_file(manifest_path);
-        } else {
-            internal::check_logdir_format(location_);
         }
     }
 
@@ -93,6 +91,7 @@ void datastore::recover() const noexcept {
 }
 
 void datastore::ready() noexcept {
+    internal::check_logdir_format(location_);
     create_snapshot();
     state_ = state::ready;
 }

--- a/src/limestone/datastore_format.cpp
+++ b/src/limestone/datastore_format.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <boost/filesystem/operations.hpp>
+#include <nlohmann/json.hpp>
+
+#include <glog/logging.h>
+#include <limestone/logging.h>
+#include "logging_helper.h"
+
+#include <limestone/api/datastore.h>
+
+#include "internal.h"
+#include "log_entry.h"
+
+namespace limestone::internal {
+using namespace limestone::api;
+
+// setup log-dir with no data
+void setup_initial_logdir(const boost::filesystem::path& logdir) {
+    nlohmann::json manifest_v1 = {
+        { "format_version", "1.0" },
+        { "persistent_format_version", 1 }
+    };
+    boost::filesystem::path config = logdir / std::string(manifest_file_name);
+    FILE* strm = fopen(config.c_str(), "w");  // NOLINT(*-owning-memory)
+    if (!strm) {
+        LOG_LP(ERROR) << "fopen for write failed, errno = " << errno;
+        throw std::runtime_error("I/O error");
+    }
+    std::string manifest_str = manifest_v1.dump(4);
+    auto ret = fwrite(manifest_str.c_str(), manifest_str.length(), 1, strm);
+    if (ret != 1) {
+        LOG_LP(ERROR) << "fwrite failed, errno = " << errno;
+        throw std::runtime_error("I/O error");
+    }
+    if (fflush(strm) != 0) {
+        LOG_LP(ERROR) << "fflush failed, errno = " << errno;
+        throw std::runtime_error("I/O error");
+    }
+    if (fsync(fileno(strm)) != 0) {
+        LOG_LP(ERROR) << "fsync failed, errno = " << errno;
+        throw std::runtime_error("I/O error");
+    }
+    if (fclose(strm) != 0) {  // NOLINT(*-owning-memory)
+        LOG_LP(ERROR) << "fclose failed, errno = " << errno;
+        throw std::runtime_error("I/O error");
+    }
+}
+
+void check_logdir_format(const boost::filesystem::path& logdir) {
+    boost::filesystem::path manifest_path = logdir / std::string(manifest_file_name);
+    std::ifstream istrm(manifest_path.string());
+    if (!istrm) {
+        LOG_LP(ERROR) << "no config file in logdir, maybe v0";
+        throw std::runtime_error("logdir version mismatch");
+    }
+    nlohmann::json manifest;
+    istrm >> manifest;
+    auto version = manifest["persistent_format_version"];
+    if (!version.is_number_integer() || version != 1) {
+        LOG_LP(ERROR) << "logdir version mismatch: version = " << version;
+        throw std::runtime_error("logdir version mismatch");
+    }
+}
+
+} // namespace limestone::internal

--- a/src/limestone/datastore_format.cpp
+++ b/src/limestone/datastore_format.cpp
@@ -61,18 +61,37 @@ void setup_initial_logdir(const boost::filesystem::path& logdir) {
     }
 }
 
-void check_logdir_format(const boost::filesystem::path& logdir) {
-    boost::filesystem::path manifest_path = logdir / std::string(manifest_file_name);
+bool is_supported_version(const boost::filesystem::path& manifest_path, std::string& errmsg) {
     std::ifstream istrm(manifest_path.string());
     if (!istrm) {
+        errmsg = "cannot open for read " + manifest_path.string();
+        return false;
+    }
+    nlohmann::json manifest;
+    try {
+        istrm >> manifest;
+        auto version = manifest["persistent_format_version"];
+        if (!version.is_number_integer() || version != 1) {
+            errmsg = "format version mismatch: version = " + version.dump();
+            return false;
+        }
+    } catch (nlohmann::json::exception& e) {
+        errmsg = "JSON read error: ";
+        errmsg.append(e.what());
+        return false;
+    };
+    return true;
+}
+
+void check_logdir_format(const boost::filesystem::path& logdir) {
+    boost::filesystem::path manifest_path = logdir / std::string(manifest_file_name);
+    if (!boost::filesystem::exists(manifest_path)) {
         LOG_LP(ERROR) << "no config file in logdir, maybe v0";
         throw std::runtime_error("logdir version mismatch");
     }
-    nlohmann::json manifest;
-    istrm >> manifest;
-    auto version = manifest["persistent_format_version"];
-    if (!version.is_number_integer() || version != 1) {
-        LOG_LP(ERROR) << "logdir version mismatch: version = " << version;
+    std::string errmsg;
+    if (!is_supported_version(manifest_path, errmsg)) {
+        LOG_LP(ERROR) << errmsg;
         throw std::runtime_error("logdir version mismatch");
     }
 }

--- a/src/limestone/internal.h
+++ b/src/limestone/internal.h
@@ -30,6 +30,8 @@ inline constexpr const std::string_view manifest_file_name = "limestone-manifest
 
 void setup_initial_logdir(const boost::filesystem::path& logdir);
 
+bool is_supported_version(const boost::filesystem::path& manifest_path, std::string& errmsg);
+
 void check_logdir_format(const boost::filesystem::path& logdir);
 
 }

--- a/src/limestone/internal.h
+++ b/src/limestone/internal.h
@@ -26,4 +26,10 @@ std::optional<epoch_id_type> last_durable_epoch(const boost::filesystem::path& f
 
 epoch_id_type scan_one_pwal_file(const boost::filesystem::path& pwal, epoch_id_type ld_epoch, const std::function<void(log_entry&)>& add_entry);
 
+inline constexpr const std::string_view manifest_file_name = "limestone-manifest.json";
+
+void setup_initial_logdir(const boost::filesystem::path& logdir);
+
+void check_logdir_format(const boost::filesystem::path& logdir);
+
 }

--- a/test/limestone/log/log_channel_test.cpp
+++ b/test/limestone/log/log_channel_test.cpp
@@ -77,12 +77,14 @@ TEST_F(log_channel_test, number_and_backup) {
     auto& backup = datastore_->begin_backup();
     auto files = backup.files();
 
-    EXPECT_EQ(files.size(), 5);
-    EXPECT_EQ(files.at(0).string(), std::string(location) + "/epoch");
-    EXPECT_EQ(files.at(1).string(), std::string(location) + "/pwal_0000");
-    EXPECT_EQ(files.at(2).string(), std::string(location) + "/pwal_0001");
-    EXPECT_EQ(files.at(3).string(), std::string(location) + "/pwal_0002");
-    EXPECT_EQ(files.at(4).string(), std::string(location) + "/pwal_0003");
+    int manifest_file_num = 0;
+    EXPECT_EQ(files.size(), 5 + manifest_file_num);
+    int i = 0;
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/epoch");
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0000");
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0001");
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0002");
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0003");
 }
 
 TEST_F(log_channel_test, remove) {

--- a/test/limestone/log/log_channel_test.cpp
+++ b/test/limestone/log/log_channel_test.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 #include <unistd.h>
+#include "internal.h"
 #include "test_root.h"
+
+#define LOGFORMAT_V1
 
 namespace limestone::testing {
 
@@ -77,10 +80,17 @@ TEST_F(log_channel_test, number_and_backup) {
     auto& backup = datastore_->begin_backup();
     auto files = backup.files();
 
+#ifdef LOGFORMAT_V1
+    int manifest_file_num = 1;
+#else
     int manifest_file_num = 0;
+#endif
     EXPECT_EQ(files.size(), 5 + manifest_file_num);
     int i = 0;
     EXPECT_EQ(files.at(i++).string(), std::string(location) + "/epoch");
+#ifdef LOGFORMAT_V1
+    EXPECT_EQ(files.at(i++).string(), std::string(location) + "/" + std::string(limestone::internal::manifest_file_name));
+#endif
     EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0000");
     EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0001");
     EXPECT_EQ(files.at(i++).string(), std::string(location) + "/pwal_0002");

--- a/test/limestone/log/log_dir_test.cpp
+++ b/test/limestone/log/log_dir_test.cpp
@@ -47,6 +47,7 @@ extern void create_file(boost::filesystem::path path, std::string_view content);
 
 TEST_F(log_dir_test, newly_created_directory_contains_manifest_file) {
     gen_datastore();
+    limestone::internal::check_logdir_format(location);
 
     EXPECT_TRUE(boost::filesystem::exists(manifest_path));
 }
@@ -54,21 +55,23 @@ TEST_F(log_dir_test, newly_created_directory_contains_manifest_file) {
 TEST_F(log_dir_test, reject_directory_without_manifest_file) {
     create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
 
-    EXPECT_THROW({ gen_datastore(); }, std::exception);
-
+    gen_datastore();
+    EXPECT_THROW({ limestone::internal::check_logdir_format(location); }, std::exception);
 }
 
 TEST_F(log_dir_test, reject_directory_with_broken_manifest_file) {
     create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
     create_file(manifest_path, "broken");
 
-    EXPECT_THROW({ gen_datastore(); }, std::exception);
+    gen_datastore();
+    EXPECT_THROW({ limestone::internal::check_logdir_format(location); }, std::exception);
 }
 
 TEST_F(log_dir_test, reject_directory_only_broken_manifest_file) {
     create_file(manifest_path, "broken");
 
-    EXPECT_THROW({ gen_datastore(); }, std::exception);
+    gen_datastore();
+    EXPECT_THROW({ limestone::internal::check_logdir_format(location); }, std::exception);
 }
 
 TEST_F(log_dir_test, reject_directory_only_broken_manifest_file2) {
@@ -82,20 +85,23 @@ TEST_F(log_dir_test, accept_directory_with_correct_manifest_file) {
     create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
     create_file(manifest_path, "{ \"format_version\": \"1.0\", \"persistent_format_version\": 1 }");
 
-    gen_datastore();  // success
+    gen_datastore();
+    limestone::internal::check_logdir_format(location);  // success
 }
 
 TEST_F(log_dir_test, accept_directory_only_correct_manifest_file) {
     create_file(manifest_path, "{ \"format_version\": \"1.0\", \"persistent_format_version\": 1 }");
 
-    gen_datastore();  // success
+    gen_datastore();
+    limestone::internal::check_logdir_format(location);  // success
 }
 
 TEST_F(log_dir_test, reject_directory_of_different_version) {
     create_file(boost::filesystem::path(location) / std::string(limestone::internal::manifest_file_name),
                 "{ \"format_version\": \"1.0\", \"persistent_format_version\": 222 }");
 
-    EXPECT_THROW({ gen_datastore(); }, std::exception);
+    gen_datastore();
+    EXPECT_THROW({ limestone::internal::check_logdir_format(location); }, std::exception);
 }
 
 }  // namespace limestone::testing

--- a/test/limestone/log/log_dir_test.cpp
+++ b/test/limestone/log/log_dir_test.cpp
@@ -1,0 +1,101 @@
+
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+#include <limestone/logging.h>
+
+#include "internal.h"
+#include "log_entry.h"
+
+#include "test_root.h"
+
+namespace limestone::testing {
+
+class log_dir_test : public ::testing::Test {
+public:
+static constexpr const char* location = "/tmp/log_dir_test";
+const boost::filesystem::path manifest_path = boost::filesystem::path(location) / std::string(limestone::internal::manifest_file_name);
+
+    void SetUp() {
+        boost::filesystem::remove_all(location);
+        if (!boost::filesystem::create_directory(location)) {
+            std::cerr << "cannot make directory" << std::endl;
+        }
+    }
+
+    void gen_datastore() {
+        std::vector<boost::filesystem::path> data_locations{};
+        data_locations.emplace_back(location);
+        boost::filesystem::path metadata_location{location};
+        limestone::api::configuration conf(data_locations, metadata_location);
+
+        datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
+    }
+
+    void TearDown() {
+        datastore_ = nullptr;
+        boost::filesystem::remove_all(location);
+    }
+
+    bool starts_with(std::string a, std::string b) { return a.substr(0, b.length()) == b; };
+
+protected:
+    std::unique_ptr<limestone::api::datastore_test> datastore_{};
+};
+
+extern void create_file(boost::filesystem::path path, std::string_view content);
+
+TEST_F(log_dir_test, newly_created_directory_contains_manifest_file) {
+    gen_datastore();
+
+    EXPECT_TRUE(boost::filesystem::exists(manifest_path));
+}
+
+TEST_F(log_dir_test, reject_directory_without_manifest_file) {
+    create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
+
+    EXPECT_THROW({ gen_datastore(); }, std::exception);
+
+}
+
+TEST_F(log_dir_test, reject_directory_with_broken_manifest_file) {
+    create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
+    create_file(manifest_path, "broken");
+
+    EXPECT_THROW({ gen_datastore(); }, std::exception);
+}
+
+TEST_F(log_dir_test, reject_directory_only_broken_manifest_file) {
+    create_file(manifest_path, "broken");
+
+    EXPECT_THROW({ gen_datastore(); }, std::exception);
+}
+
+TEST_F(log_dir_test, reject_directory_only_broken_manifest_file2) {
+    create_file(manifest_path, "{ \"answer\": 42 }");
+
+    gen_datastore();
+    EXPECT_THROW({ limestone::internal::check_logdir_format(location); }, std::exception);
+}
+
+TEST_F(log_dir_test, accept_directory_with_correct_manifest_file) {
+    create_file(boost::filesystem::path(location) / "epoch", "\x04\x00\x00\x00\x00\x00\x00\x00\x00");
+    create_file(manifest_path, "{ \"format_version\": \"1.0\", \"persistent_format_version\": 1 }");
+
+    gen_datastore();  // success
+}
+
+TEST_F(log_dir_test, accept_directory_only_correct_manifest_file) {
+    create_file(manifest_path, "{ \"format_version\": \"1.0\", \"persistent_format_version\": 1 }");
+
+    gen_datastore();  // success
+}
+
+TEST_F(log_dir_test, reject_directory_of_different_version) {
+    create_file(boost::filesystem::path(location) / std::string(limestone::internal::manifest_file_name),
+                "{ \"format_version\": \"1.0\", \"persistent_format_version\": 222 }");
+
+    EXPECT_THROW({ gen_datastore(); }, std::exception);
+}
+
+}  // namespace limestone::testing


### PR DESCRIPTION
永続化データフォーマットのバージョンを導入する変更です
* 空の logdir に対して datastore オブジェクトを作成すると、version 1 の マニフェストファイルを作成します
* `datastore::ready()` メソッドを呼ぶと、logdir のデータフォーマットバージョンをチェックし、 version 1 でなかった場合にはエラーを返します (例外)
* バックアップからのリストア時には、データフォーマットバージョンをチェックし、 version 1 でなかった場合にはエラーを返します (エラーコード)


案件: https://github.com/project-tsurugi/tsurugi-issues/issues/418
