### PR TITLE
build: make RPATH relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ option(PERFORMANCE_TOOLS "Enable tooling to measure engine performance" OFF)
 option(TRACY_ENABLE "enable tracy profiler" OFF)
 option(ENABLE_ALTIMETER "enable altimeter logging" OFF)
 
+if (FORCE_INSTALL_RPATH)
+    message(DEPRECATION "FORCE_INSTALL_RPATH is obsoleted")
+endif (FORCE_INSTALL_RPATH)
+
 if (ENABLE_GOOGLE_PERFTOOLS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_GOOGLE_PERFTOOLS")
 endif()
@@ -139,7 +143,7 @@ install(
     COMPONENT Development
     FILES_MATCHING PATTERN "*.h"
 )
-  
+
 configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config.cmake

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ available options:
 * `-DBUILD_TESTS=OFF` - don't build test programs
 * `-DBUILD_DOCUMENTS=OFF` - don't build documents by doxygen
 * `-DINSTALL_EXAMPLES=ON` - install example applications
-* `-DFORCE_INSTALL_RPATH=ON` - automatically configure `INSTALL_RPATH` for non-default library paths
 * `-DRECOVERY_SORTER_KVSLIB=<library>` - select the eKVS library using at recovery process. (`LEVELDB` (default) or `ROCKSDB`, case-insensitive)
 * `-DRECOVERY_SORTER_PUT_ONLY=ON` - using put-only method at recovery process (faster)
 * for debugging only
@@ -51,8 +50,8 @@ available options:
   * `-DENABLE_COVERAGE=ON` - enable code coverage analysis (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DTRACY_ENABLE=ON` - enable tracy profiler for multi-thread debugging. See section below.
   * `-DLIKWID_ENABLE=ON` - enable LIKWID for performance metrics. See section below.
-    
-### install 
+
+### install
 
 ```sh
 cmake --build . --target install

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -14,37 +14,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,11 @@ add_library(${package_name}
         ${SOURCES}
 )
 
-set_target_properties(${package_name} PROPERTIES
-        OUTPUT_NAME ${export_name}
-        )
+set_target_properties(${package_name}
+        PROPERTIES
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                OUTPUT_NAME ${export_name}
+)
 
 if(${RECOVERY_SORTER_KVSLIB_UPPERCASE} STREQUAL "ROCKSDB")
     set(sort_lib RocksDB::RocksDB)
@@ -70,5 +72,9 @@ target_include_directories(dblogutil
         PRIVATE ./limestone
         )
 target_link_libraries(dblogutil PRIVATE limestone-impl PRIVATE glog::glog gflags::gflags)
-set_target_properties(dblogutil PROPERTIES RUNTIME_OUTPUT_NAME "tglogutil")
+set_target_properties(dblogutil
+        PROPERTIES
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "tglogutil"
+)
 install_custom(dblogutil dblogutil)


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.