### PR TITLE
datastore::switch_epochとlog_channel::begin_sessionの呼出しがオーバラップする可能性についてapi コメントに追記

### DIFF
--- a/include/limestone/api/log_channel.h
+++ b/include/limestone/api/log_channel.h
@@ -48,8 +48,9 @@ public:
      * @brief join a persistence session for the current epoch in this channel
      * @attention this function is not thread-safe.
      * @note the current epoch is the last epoch specified by datastore::switch_epoch()
-     * @note datastore::switch_epoch() and this function can be called simultaneously. 
-     * If these functions invocation overwrap, the current epoch that the session joins depends on timing. 
+     * @note datastore::switch_epoch() and this function can be called simultaneously.
+     * If these functions are invoked at the same time, the result will be as if one of them was called first, 
+     * but it is indeterminate which one will take precedence.
      */
     void begin_session();
 

--- a/include/limestone/api/log_channel.h
+++ b/include/limestone/api/log_channel.h
@@ -48,6 +48,8 @@ public:
      * @brief join a persistence session for the current epoch in this channel
      * @attention this function is not thread-safe.
      * @note the current epoch is the last epoch specified by datastore::switch_epoch()
+     * @note datastore::switch_epoch() and this function can be called simultaneously. 
+     * If these functions invocation overwrap, the current epoch that the session joins depends on timing. 
      */
     void begin_session();
 


### PR DESCRIPTION
会議で議論した内容 ( https://github.com/project-tsurugi/tsurugi-issues/issues/925 )に従ってlimestone API doc commentに追記したいと思います。

@umegane レビューのうえ、問題なければマージお願いします。
