### PR TITLE
Dev umegane 1105

### DIFF
--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -257,8 +257,20 @@ protected:  // for tests
     // They allow derived classes to inject custom behavior or notifications
     // at specific wait points during the execution of the datastore class.
     // The default implementation does nothing, ensuring no impact on production code.
-    virtual void on_rotate_log_files() {}
-
+    virtual void on_rotate_log_files() noexcept {}
+    virtual void on_begin_session_current_epoch_id_store() noexcept {}
+    virtual void on_end_session_finished_epoch_id_store() noexcept {}
+    virtual void on_end_session_current_epoch_id_store() noexcept {}
+    virtual void on_switch_epoch_epoch_id_switched_store() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_switched_load() noexcept {}
+    virtual void on_update_min_epoch_id_current_epoch_id_load() noexcept {}
+    virtual void on_update_min_epoch_id_finished_epoch_id_load() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_to_be_recorded_load() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_to_be_recorded_cas() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_record_finished_load() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_informed_load_1() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_informed_cas() noexcept {}
+    virtual void on_update_min_epoch_id_epoch_id_informed_load_2() noexcept {}
 private:
     std::vector<std::unique_ptr<log_channel>> log_channels_;
 

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -257,10 +257,7 @@ protected:  // for tests
     // They allow derived classes to inject custom behavior or notifications
     // at specific wait points during the execution of the datastore class.
     // The default implementation does nothing, ensuring no impact on production code.
-    virtual void on_wait1() {}
-    virtual void on_wait2() {}
-    virtual void on_wait3() {}
-    virtual void on_wait4() {}
+    virtual void on_rotate_log_files() {}
 
 private:
     std::vector<std::unique_ptr<log_channel>> log_channels_;

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -274,22 +274,39 @@ protected:  // for tests
     virtual void on_update_min_epoch_id_epoch_id_informed_load_2() noexcept {}
 
     /**
-     * @brief Callback function for writing epoch to file.
+     * @brief Sets the callback function for writing epoch to a file.
      * @details
-     * This callback is used to define the behavior for writing epoch information to a file.
-     * By default, it calls the `write_epoch_to_file` method. 
+     * This method allows you to override the default behavior for writing epoch 
+     * information by providing a custom callback. The callback can be a free 
+     * function, a lambda, or a member function bound to an object.
      * 
-     * - **Purpose**: This callback is intended for testing purposes only.
-     * - **Restriction**: It should not be modified in production code.
+     * Example:
+     * @code
+     * class CustomHandler {
+     * public:
+     *     void custom_epoch_writer(epoch_id_type epoch) {
+     *         // Custom logic
+     *     }
+     * };
      * 
-     * Derived classes for testing can modify this callback to alter the behavior
-     * without modifying the base class implementation.
+     * datastore ds;
+     * CustomHandler handler;
+     * ds.set_write_epoch_callback([&handler](epoch_id_type epoch) {
+     *     handler.custom_epoch_writer(epoch);
+     * });
+     * @endcode
+     * 
+     * @param callback The new callback function to use for writing epoch.
      */
+    void set_write_epoch_callback(std::function<void(epoch_id_type)> callback) {
+        write_epoch_callback_ = std::move(callback);
+    }
+
+private:
     std::function<void(epoch_id_type)> write_epoch_callback_{
         [this](epoch_id_type epoch) { this->write_epoch_to_file(epoch); }
     };
 
-private:
     std::vector<std::unique_ptr<log_channel>> log_channels_;
 
     boost::filesystem::path location_{};

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -248,7 +248,8 @@ public:
 protected:  // for tests
     auto& log_channels_for_tests() const noexcept { return log_channels_; }
     auto epoch_id_informed_for_tests() const noexcept { return epoch_id_informed_.load(); }
-    auto epoch_id_recorded_for_tests() const noexcept { return epoch_id_to_be_recorded_.load(); }
+    auto epoch_id_to_be_recorded_for_tests() const noexcept { return epoch_id_to_be_recorded_.load(); }
+    auto epoch_id_record_finished_for_tests() const noexcept { return epoch_id_record_finished_.load(); }
     auto epoch_id_switched_for_tests() const noexcept { return epoch_id_switched_.load(); }
     auto& files_for_tests() const noexcept { return files_; }
     void rotate_epoch_file_for_tests() { rotate_epoch_file(); }
@@ -271,6 +272,23 @@ protected:  // for tests
     virtual void on_update_min_epoch_id_epoch_id_informed_load_1() noexcept {}
     virtual void on_update_min_epoch_id_epoch_id_informed_cas() noexcept {}
     virtual void on_update_min_epoch_id_epoch_id_informed_load_2() noexcept {}
+
+    /**
+     * @brief Callback function for writing epoch to file.
+     * @details
+     * This callback is used to define the behavior for writing epoch information to a file.
+     * By default, it calls the `write_epoch_to_file` method. 
+     * 
+     * - **Purpose**: This callback is intended for testing purposes only.
+     * - **Restriction**: It should not be modified in production code.
+     * 
+     * Derived classes for testing can modify this callback to alter the behavior
+     * without modifying the base class implementation.
+     */
+    std::function<void(epoch_id_type)> write_epoch_callback_{
+        [this](epoch_id_type epoch) { this->write_epoch_to_file(epoch); }
+    };
+
 private:
     std::vector<std::unique_ptr<log_channel>> log_channels_;
 
@@ -376,7 +394,7 @@ private:
     // File descriptor for file lock (flock) on the manifest file
     int fd_for_flock_{-1};
 
-    void write_epoch_to_file(epoch_id_type epoch_id);
+    virtual void write_epoch_to_file(epoch_id_type epoch_id);
 
     int epoch_write_counter = 0;
 };

--- a/include/limestone/api/log_channel.h
+++ b/include/limestone/api/log_channel.h
@@ -164,6 +164,16 @@ public:
      */
     [[nodiscard]] boost::filesystem::path file_path() const noexcept;
 
+    /**
+     * @brief this is for test purpose only, must not be used for any purpose other than testing
+     */
+    [[nodiscard]] auto current_epoch_id() const noexcept { return current_epoch_id_.load(); }
+
+    /**
+     * @brief this is for test purpose only, must not be used for any purpose other than testing
+     */
+    [[nodiscard]] auto finished_epoch_id() const noexcept { return finished_epoch_id_.load(); }
+
 private:
     datastore& envelope_;
 
@@ -183,10 +193,11 @@ private:
 
     std::atomic_uint64_t finished_epoch_id_{0};
 
-    log_channel(boost::filesystem::path location, std::size_t id, datastore& envelope) noexcept;
-
     std::string do_rotate_file(epoch_id_type epoch = 0);
 
+protected: // Protected to allow testing with derived classes
+    log_channel(boost::filesystem::path location, std::size_t id, datastore& envelope) noexcept;
+ 
     friend class datastore;
     friend class rotation_task;
 };

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -486,7 +486,7 @@ rotation_result datastore::rotate_log_files() {
     }
     TRACE << "epoch_id = " << epoch_id;
     {
-        on_wait1(); // for testing
+        on_rotate_log_files(); // for testing
         // Wait until epoch_id_informed_ is less than rotated_epoch_id to ensure safe rotation.
         std::unique_lock<std::mutex> ul(informed_mutex);
         while (epoch_id_informed_.load() < epoch_id) {

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -224,6 +224,7 @@ void datastore::switch_epoch(epoch_id_type new_epoch_id) {
             LOG_LP(WARNING) << "switch to epoch_id_type of " << neid << " (<=" << switched << ") is curious";
         }
 
+        on_switch_epoch_epoch_id_switched_store();    // for testing
         epoch_id_switched_.store(neid);
         if (state_ != state::not_ready) {
             update_min_epoch_id(true);
@@ -237,6 +238,8 @@ void datastore::switch_epoch(epoch_id_type new_epoch_id) {
 
 void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readability-function-cognitive-complexity)
     TRACE_START << "from_switch_epoch=" << from_switch_epoch;
+    
+    on_update_min_epoch_id_epoch_id_switched_load(); // for testing
     auto upper_limit = epoch_id_switched_.load();
     if (upper_limit == 0) {
         return; // If epoch_id_switched_ is zero, it means no epoch has been switched, so updating epoch_id_to_be_recorded_ and epoch_id_informed_ is unnecessary.
@@ -246,7 +249,9 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readabi
     epoch_id_type max_finished_epoch = 0;
 
     for (const auto& e : log_channels_) {
+        on_update_min_epoch_id_current_epoch_id_load(); // for testing
         auto working_epoch = e->current_epoch_id_.load();
+        on_update_min_epoch_id_finished_epoch_id_load(); // for testing
         auto finished_epoch = e->finished_epoch_id_.load();
         if (working_epoch > finished_epoch && working_epoch != UINT64_MAX) {
             if ((working_epoch - 1) < upper_limit) {
@@ -267,13 +272,16 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readabi
     }
 
     TRACE << "update epoch file part start with to_be_epoch = " << to_be_epoch;
+    on_update_min_epoch_id_epoch_id_to_be_recorded_load();  // for testing
     auto old_epoch_id = epoch_id_to_be_recorded_.load();
     while (true) {
         if (old_epoch_id >= to_be_epoch) {
             break;
         }
+        on_update_min_epoch_id_epoch_id_to_be_recorded_cas();  // for testing
         if (epoch_id_to_be_recorded_.compare_exchange_strong(old_epoch_id, to_be_epoch)) {
             TRACE << "epoch_id_to_be_recorded_ updated to " << to_be_epoch;
+            on_update_min_epoch_id_epoch_id_to_be_recorded_load();  // for testing
             std::lock_guard<std::mutex> lock(mtx_epoch_file_);
             if (to_be_epoch < epoch_id_to_be_recorded_.load()) {
                 break;
@@ -284,6 +292,7 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readabi
             break;
         }
     }
+    on_update_min_epoch_id_epoch_id_record_finished_load();  // for testing
     if (to_be_epoch > epoch_id_record_finished_.load()) {
         TRACE << "skipping persistent callback part, to_be_epoch =  " << to_be_epoch << ", epoch_id_record_finished_ = " << epoch_id_record_finished_.load();
         TRACE_END;
@@ -296,14 +305,17 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readabi
     // In `informed_epoch_`, the update restriction based on the `from_switch_epoch` condition is intentionally omitted.
     // Due to the interface specifications of Shirakami, it is necessary to advance the epoch even if the log channel
     // is not updated. This behavior differs from `recorded_epoch_` and should be maintained as such.
+    on_update_min_epoch_id_epoch_id_informed_load_1();  // for testing
     old_epoch_id = epoch_id_informed_.load();
     while (true) {
         if (old_epoch_id >= to_be_epoch) {
             break;
         }
+        on_update_min_epoch_id_epoch_id_informed_cas();  // for testing
         if (epoch_id_informed_.compare_exchange_strong(old_epoch_id, to_be_epoch)) {
             TRACE << "epoch_id_informed_ updated to " << to_be_epoch;
             {
+                on_update_min_epoch_id_epoch_id_informed_load_2();  // for testing
                 std::lock_guard<std::mutex> lock(mtx_epoch_persistent_callback_);
                 if (to_be_epoch < epoch_id_informed_.load()) {
                     break;

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -184,7 +184,7 @@ void datastore::ready() {
         create_snapshot();
         online_compaction_worker_future_ = std::async(std::launch::async, &datastore::online_compaction_worker, this);
         if (epoch_id_switched_.load() != 0) {
-            write_epoch_to_file(epoch_id_informed_.load());
+            write_epoch_callback_(epoch_id_informed_.load());
         }
         cleanup_rotated_epoch_files(location_);
         state_ = state::ready;
@@ -286,7 +286,7 @@ void datastore::update_min_epoch_id(bool from_switch_epoch) {  // NOLINT(readabi
             if (to_be_epoch < epoch_id_to_be_recorded_.load()) {
                 break;
             }           
-            write_epoch_to_file(static_cast<epoch_id_type>(to_be_epoch));
+            write_epoch_callback_(static_cast<epoch_id_type>(to_be_epoch));
             epoch_id_record_finished_.store(to_be_epoch);
             TRACE << "epoch_id_record_finished_ updated to " << to_be_epoch;
             break;

--- a/src/limestone/logging_helper.h
+++ b/src/limestone/logging_helper.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <glog/logging.h>
 #include <array>
 #include <string_view>
 #include <thread>

--- a/test/limestone/epoch/finish_soon_test.cpp
+++ b/test/limestone/epoch/finish_soon_test.cpp
@@ -46,25 +46,25 @@ TEST_F(finish_soon_test, same) {
 
     datastore_->switch_epoch(2);
     ASSERT_EQ(1, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
 
     datastore_->switch_epoch(3);
     ASSERT_EQ(2, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
 
     channel.begin_session();
     channel.end_session();
     
     ASSERT_EQ(2, datastore_->epoch_id_informed());
-    ASSERT_EQ(2, datastore_->epoch_id_recorded());
+    ASSERT_EQ(2, datastore_->epoch_id_to_be_recorded());
 
     datastore_->switch_epoch(4);
     ASSERT_EQ(3, datastore_->epoch_id_informed());
-    ASSERT_EQ(3, datastore_->epoch_id_recorded());
+    ASSERT_EQ(3, datastore_->epoch_id_to_be_recorded());
     
     datastore_->switch_epoch(5);
     ASSERT_EQ(4, datastore_->epoch_id_informed());
-    ASSERT_EQ(3, datastore_->epoch_id_recorded());
+    ASSERT_EQ(3, datastore_->epoch_id_to_be_recorded());
 
     // cleanup
     datastore_->shutdown();
@@ -77,27 +77,27 @@ TEST_F(finish_soon_test, different) {
 
     datastore_->switch_epoch(2);
     ASSERT_EQ(1, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
 
     datastore_->switch_epoch(3);
     ASSERT_EQ(2, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
 
     channel.begin_session();
     ASSERT_EQ(2, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
 
     datastore_->switch_epoch(4);
     ASSERT_EQ(2, datastore_->epoch_id_informed());
-    ASSERT_EQ(0, datastore_->epoch_id_recorded());
+    ASSERT_EQ(0, datastore_->epoch_id_to_be_recorded());
     
     channel.end_session();
     ASSERT_EQ(3, datastore_->epoch_id_informed());
-    ASSERT_EQ(3, datastore_->epoch_id_recorded());
+    ASSERT_EQ(3, datastore_->epoch_id_to_be_recorded());
 
     datastore_->switch_epoch(5);
     ASSERT_EQ(4, datastore_->epoch_id_informed());
-    ASSERT_EQ(3, datastore_->epoch_id_recorded());
+    ASSERT_EQ(3, datastore_->epoch_id_to_be_recorded());
 
     // cleanup
     datastore_->shutdown();

--- a/test/limestone/epoch/race_condition_test_manager.cpp
+++ b/test/limestone/epoch/race_condition_test_manager.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #include "race_condition_test_manager.h"
+
+namespace limestone::testing {
+
+race_condition_test_manager::race_condition_test_manager(std::vector<std::pair<test_method, size_t>> test_methods)
+    : test_methods_(std::move(test_methods)) {}
+
+void race_condition_test_manager::set_random_seed(unsigned int seed) {
+    random_engine_.seed(seed);
+}
+
+void race_condition_test_manager::run() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t thread_id_counter = 0;
+    for (const auto& [method, count] : test_methods_) {
+        for (size_t i = 0; i < count; ++i) {
+            size_t current_id = thread_id_counter++;
+            threads_.emplace_back([this, method, current_id]() {
+                static thread_local size_t thread_local_id = current_id;
+                try {
+                    method();
+                    thread_completed(current_id);
+                } catch (const std::exception& e) {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    std::cerr << "Exception in thread: " << e.what() << std::endl;
+                    thread_completed(current_id);
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    std::cerr << "Unknown exception in thread." << std::endl;
+                    thread_completed(current_id);
+                }
+            });
+        }
+    }
+}
+
+void race_condition_test_manager::wait_at_hook(const std::string& hook_name) {
+    static thread_local size_t thread_local_id; // Thread-local ID
+    size_t local_thread_id = thread_local_id;   // Copy the thread-local variable
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        pending_threads_.emplace(local_thread_id, hook_name);
+    }
+
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this, local_thread_id]() { return resumed_threads_.count(local_thread_id) > 0; });
+        resumed_threads_.erase(local_thread_id);
+    }
+}
+
+
+
+void race_condition_test_manager::resume_one_thread() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (pending_threads_.empty()) return;
+
+    std::uniform_int_distribution<size_t> dist(0, pending_threads_.size() - 1);
+    auto it = pending_threads_.begin();
+    std::advance(it, dist(random_engine_));
+    resumed_threads_.insert(it->first);
+    pending_threads_.erase(it);
+    cv_.notify_all();
+}
+
+void race_condition_test_manager::generate_and_set_random_seed() {
+    std::random_device rd;
+    unsigned int seed = rd();
+    std::cout << "Generated random seed: " << seed << std::endl;
+    set_random_seed(seed);
+}
+
+void race_condition_test_manager::wait_for_all_threads_to_pause_or_complete() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this]() {
+        return (pending_threads_.size() + threads_completed_ == threads_.size());
+    });
+}
+
+bool race_condition_test_manager::all_threads_completed() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return threads_completed_ == threads_.size();
+}
+
+void race_condition_test_manager::join_all_threads() {
+    for (auto& thread : threads_) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+}
+
+void race_condition_test_manager::thread_completed(size_t thread_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    threads_completed_++;
+    cv_.notify_all();
+}
+
+} // namespace limestone::testing

--- a/test/limestone/epoch/race_condition_test_manager.h
+++ b/test/limestone/epoch/race_condition_test_manager.h
@@ -46,6 +46,7 @@ public:
     void join_all_threads();
 
 private:
+    static thread_local size_t thread_local_id;
     std::vector<std::pair<test_method, size_t>> test_methods_;
     std::mutex mutex_;
     std::condition_variable cv_;

--- a/test/limestone/epoch/race_condition_test_manager.h
+++ b/test/limestone/epoch/race_condition_test_manager.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RACE_CONDITION_TEST_MANAGER_H
+#define RACE_CONDITION_TEST_MANAGER_H
+
+#include <vector>
+#include <map>
+#include <set>
+#include <string>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <random>
+#include <functional>
+#include <iostream>
+
+namespace limestone::testing {
+
+class race_condition_test_manager {
+public:
+    using test_method = std::function<void()>;
+
+    explicit race_condition_test_manager(std::vector<std::pair<test_method, size_t>> test_methods);
+
+    void set_random_seed(unsigned int seed);
+    void run();
+    void wait_at_hook(const std::string& hook_name);
+    void resume_one_thread();
+    void generate_and_set_random_seed();
+    void wait_for_all_threads_to_pause_or_complete();
+    bool all_threads_completed();
+    void join_all_threads();
+
+private:
+    std::vector<std::pair<test_method, size_t>> test_methods_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<std::thread> threads_;
+    std::map<size_t, std::string> pending_threads_;
+    std::set<size_t> resumed_threads_;
+    size_t threads_completed_ = 0;
+    std::mt19937 random_engine_{std::random_device{}()};
+
+    void thread_completed(size_t thread_id);
+};
+
+} // namespace limestone::testing
+
+#endif // RACE_CONDITION_TEST_MANAGER_H

--- a/test/limestone/epoch/race_detection_test.cpp
+++ b/test/limestone/epoch/race_detection_test.cpp
@@ -366,11 +366,10 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
     EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
     EXPECT_EQ(lc1_->finished_epoch_id(), 0);
     EXPECT_EQ(datastore_->epoch_id_informed(), 2);
-    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 2);
-    EXPECT_EQ(datastore_->epoch_id_record_finished(), 2);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 0);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 0);
     EXPECT_EQ(datastore_->epoch_id_switched(), 3);
-    EXPECT_EQ(datastore_->get_written_epoch_count(), 1);
-    EXPECT_EQ(datastore_->get_last_written_epoch(), 2);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 0);
     EXPECT_EQ(datastore_->get_persisted_epoch_count(), 2);
     EXPECT_EQ(datastore_->get_last_persisted_epoch(), 2);
     switch_epoch();
@@ -383,7 +382,7 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
     EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 3);
     EXPECT_EQ(datastore_->epoch_id_record_finished(), 3);
     EXPECT_EQ(datastore_->epoch_id_switched(), 4);
-    EXPECT_EQ(datastore_->get_written_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 1);
     EXPECT_EQ(datastore_->get_last_written_epoch(), 3);
     EXPECT_EQ(datastore_->get_persisted_epoch_count(), 3);
     EXPECT_EQ(datastore_->get_last_persisted_epoch(), 3);
@@ -396,7 +395,7 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
     EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 3);
     EXPECT_EQ(datastore_->epoch_id_record_finished(), 3);
     EXPECT_EQ(datastore_->epoch_id_switched(), 4);
-    EXPECT_EQ(datastore_->get_written_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 1);
     EXPECT_EQ(datastore_->get_last_written_epoch(), 3);
     EXPECT_EQ(datastore_->get_persisted_epoch_count(), 3);
     EXPECT_EQ(datastore_->get_last_persisted_epoch(), 3);
@@ -409,7 +408,7 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
     EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 4);
     EXPECT_EQ(datastore_->epoch_id_record_finished(), 4);
     EXPECT_EQ(datastore_->epoch_id_switched(), 5);
-    EXPECT_EQ(datastore_->get_written_epoch_count(), 3);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 2);
     EXPECT_EQ(datastore_->get_last_written_epoch(), 4);
     EXPECT_EQ(datastore_->get_persisted_epoch_count(), 4);
     EXPECT_EQ(datastore_->get_last_persisted_epoch(), 4);
@@ -419,7 +418,6 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
     std::vector<std::pair<std::string, epoch_id_type>> expected_log = {
         {OPERATION_PERSIST_CALLBACK, 1},
         {OPERATION_PERSIST_CALLBACK, 2},
-        {OPERATION_WRITE_EPOCH, 2},
         {OPERATION_WRITE_EPOCH, 3},
         {OPERATION_PERSIST_CALLBACK, 3},
         {OPERATION_WRITE_EPOCH, 4},

--- a/test/limestone/epoch/race_detection_test.cpp
+++ b/test/limestone/epoch/race_detection_test.cpp
@@ -42,9 +42,9 @@ class my_datastore : public datastore_test {
 public:
     explicit my_datastore(const configuration& conf) : datastore_test(conf) {
         // Set the write_epoch_callback_ to track written epochs
-        write_epoch_callback_ = [this](epoch_id_type epoch) {
+        set_write_epoch_callback([this](epoch_id_type epoch) {
             this->record_written_epoch(epoch);
-        };
+        });
 
         // Set the persistent_callback_ to track persisted epochs
         add_persistent_callback([this](epoch_id_type epoch) {

--- a/test/limestone/epoch/race_detection_test.cpp
+++ b/test/limestone/epoch/race_detection_test.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2022-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <thread>
+#include <sys/stat.h>
+#include <iostream>
+#include <vector>
+#include <mutex>
+#include <optional>
+#include <boost/filesystem.hpp>
+
+#include <limestone/logging.h>
+#include <limestone/api/datastore.h>
+
+#include "dblog_scan.h"
+#include "internal.h"
+#include "log_entry.h"
+#include "online_compaction.h"
+#include "compaction_catalog.h"
+#include "test_root.h"
+
+using namespace limestone::api;
+using namespace limestone::internal;
+
+
+namespace limestone::testing {
+
+class my_datastore : public datastore_test {
+public:
+    explicit my_datastore(const configuration& conf) : datastore_test(conf) {
+        // Set the write_epoch_callback_ to track written epochs
+        write_epoch_callback_ = [this](epoch_id_type epoch) {
+            this->record_written_epoch(epoch);
+        };
+
+        // Set the persistent_callback_ to track persisted epochs
+        add_persistent_callback([this](epoch_id_type epoch) {
+            this->record_persisted_epoch(epoch);
+        });
+    }
+
+    /**
+     * @brief Get all epochs that were successfully written.
+     * @return A vector containing all written epochs.
+     */
+    std::vector<epoch_id_type> get_written_epochs() const {
+        std::lock_guard<std::mutex> lock(mutex_written_);
+        return written_epochs_;
+    }
+
+    /**
+     * @brief Get the first written epoch.
+     * @return The first written epoch if available, otherwise std::nullopt.
+     */
+    std::optional<epoch_id_type> get_first_written_epoch() const {
+        std::lock_guard<std::mutex> lock(mutex_written_);
+        if (!written_epochs_.empty()) {
+            return written_epochs_.front();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Get the last written epoch.
+     * @return The last written epoch if available, otherwise std::nullopt.
+     */
+    std::optional<epoch_id_type> get_last_written_epoch() const {
+        std::lock_guard<std::mutex> lock(mutex_written_);
+        if (!written_epochs_.empty()) {
+            return written_epochs_.back();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Get the number of written epochs.
+     * @return The size of the written_epochs_ list.
+     */
+    std::size_t get_written_epoch_count() const {
+        std::lock_guard<std::mutex> lock(mutex_written_);
+        return written_epochs_.size();
+    }
+
+    /**
+     * @brief Get all epochs that were successfully persisted.
+     * @return A vector containing all persisted epochs.
+     */
+    std::vector<epoch_id_type> get_persisted_epochs() const {
+        std::lock_guard<std::mutex> lock(mutex_persisted_);
+        return persisted_epochs_;
+    }
+
+    /**
+     * @brief Get the first persisted epoch.
+     * @return The first persisted epoch if available, otherwise std::nullopt.
+     */
+    std::optional<epoch_id_type> get_first_persisted_epoch() const {
+        std::lock_guard<std::mutex> lock(mutex_persisted_);
+        if (!persisted_epochs_.empty()) {
+            return persisted_epochs_.front();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Get the last persisted epoch.
+     * @return The last persisted epoch if available, otherwise std::nullopt.
+     */
+    std::optional<epoch_id_type> get_last_persisted_epoch() const {
+        std::lock_guard<std::mutex> lock(mutex_persisted_);
+        if (!persisted_epochs_.empty()) {
+            return persisted_epochs_.back();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Get the number of persisted epochs.
+     * @return The size of the persisted_epochs_ list.
+     */
+    std::size_t get_persisted_epoch_count() const {
+        std::lock_guard<std::mutex> lock(mutex_persisted_);
+        return persisted_epochs_.size();
+    }
+
+private:
+    void record_written_epoch(epoch_id_type epoch) {
+        std::lock_guard<std::mutex> lock(mutex_written_);
+        written_epochs_.emplace_back(epoch);
+    }
+
+    void record_persisted_epoch(epoch_id_type epoch) {
+        std::lock_guard<std::mutex> lock(mutex_persisted_);
+        persisted_epochs_.emplace_back(epoch);
+    }
+
+    mutable std::mutex mutex_written_;  // Protects access to the written_epochs_ list
+    mutable std::mutex mutex_persisted_;  // Protects access to the persisted_epochs_ list
+    std::vector<epoch_id_type> written_epochs_;  // Stores successfully written epochs
+    std::vector<epoch_id_type> persisted_epochs_;  // Stores successfully persisted epochs
+};
+
+class race_detection_test : public ::testing::Test {
+public:
+    static constexpr const char* location = "/tmp/race_detection_test";
+
+    void SetUp() {
+        if (boost::filesystem::exists(location)) {
+            boost::filesystem::permissions(location, boost::filesystem::owner_all);
+        }
+        boost::filesystem::remove_all(location);
+        if (!boost::filesystem::create_directory(location)) {
+            std::cerr << "cannot make directory" << std::endl;
+        }
+        gen_datastore();
+        datastore_->ready();
+        datastore_->switch_epoch(1);
+    }
+
+    void gen_datastore() {
+        std::vector<boost::filesystem::path> data_locations{};
+        data_locations.emplace_back(location);
+        boost::filesystem::path metadata_location{location};
+        limestone::api::configuration conf(data_locations, metadata_location);
+
+        datastore_ = std::make_unique<my_datastore>(conf);
+        lc0_ = &datastore_->create_channel(location);
+        lc1_ = &datastore_->create_channel(location);
+    }
+
+    void TearDown() {
+        datastore_->shutdown();
+        datastore_ = nullptr;
+        if (boost::filesystem::exists(location)) {
+            boost::filesystem::permissions(location, boost::filesystem::owner_all);
+        }
+        boost::filesystem::remove_all(location);
+    }
+
+protected:
+    std::unique_ptr<my_datastore> datastore_{};
+    log_channel* lc0_{};
+    log_channel* lc1_{};
+    std::atomic_uint64_t epoch_id_{1};
+
+    void switch_epoch() {
+        epoch_id_.fetch_add(1);
+        datastore_->switch_epoch(epoch_id_.load());
+    }
+
+    void write_to_log_channel0() {
+        lc0_->begin_session();
+        lc0_->end_session();
+    }
+
+    void write_to_log_channel1() {
+        lc1_->begin_session();
+        lc1_->end_session();
+    }
+
+};
+
+
+TEST_F(race_detection_test, race_detection_behavior_test) {
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 0);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 0);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 0);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 0);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 0);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 1);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 0);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 0);
+    switch_epoch();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 0);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 0);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 1);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 0);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 0);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 2);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 0);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 1);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 1);
+    switch_epoch();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 0);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 0);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 2);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 0);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 0);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 3);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 0);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 2);
+    write_to_log_channel0();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 3);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 0);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 2);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 2);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 2);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 3);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 1);
+    EXPECT_EQ(datastore_->get_last_written_epoch(), 2);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 2);
+    switch_epoch();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 3);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 0);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 3);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 3);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 3);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 4);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_last_written_epoch(), 3);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 3);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 3);
+    write_to_log_channel1();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 3);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 4);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 3);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 3);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 3);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 4);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 2);
+    EXPECT_EQ(datastore_->get_last_written_epoch(), 3);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 3);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 3);
+    switch_epoch();
+    EXPECT_EQ(lc0_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc0_->finished_epoch_id(), 3);
+    EXPECT_EQ(lc1_->current_epoch_id(), UINT64_MAX);
+    EXPECT_EQ(lc1_->finished_epoch_id(), 4);
+    EXPECT_EQ(datastore_->epoch_id_informed(), 4);
+    EXPECT_EQ(datastore_->epoch_id_to_be_recorded(), 4);
+    EXPECT_EQ(datastore_->epoch_id_record_finished(), 4);
+    EXPECT_EQ(datastore_->epoch_id_switched(), 5);
+    EXPECT_EQ(datastore_->get_written_epoch_count(), 3);
+    EXPECT_EQ(datastore_->get_last_written_epoch(), 4);
+    EXPECT_EQ(datastore_->get_persisted_epoch_count(), 4);
+    EXPECT_EQ(datastore_->get_last_persisted_epoch(), 4);
+}
+
+
+} // namespace limestone::testing
+
+

--- a/test/test_root.h
+++ b/test/test_root.h
@@ -36,15 +36,82 @@ public:
     void rotate_epoch_file() { rotate_epoch_file_for_tests(); }
 
 protected:
-    // Overrides for on_rotate_log_files to on_wait hooks to enable custom behavior during testing.
-    void on_rotate_log_files() override {
-        if (on_rotate_log_files_callback) on_rotate_log_files_callback();  // Executes the registered callback if set
+    inline void execute_callback(const std::function<void()>& callback) noexcept {
+        if (callback) {
+            callback();
+        }
     }
 
+    // Overrides for hook methods in the datastore class.
+    // These hooks provide customizable behavior for testing various operations, including
+    // epoch management, log rotation, and session handling.
+    void on_rotate_log_files() noexcept override {
+        execute_callback(on_rotate_log_files_callback);
+    }
+    void on_begin_session_current_epoch_id_store() noexcept override {
+        execute_callback(on_begin_session_current_epoch_id_store_callback);
+    }
+    void on_end_session_finished_epoch_id_store() noexcept override {
+        execute_callback(on_end_session_finished_epoch_id_store_callback);
+    }
+    void on_end_session_current_epoch_id_store() noexcept override {
+        execute_callback(on_end_session_current_epoch_id_store_callback);
+    }
+    void on_switch_epoch_epoch_id_switched_store() noexcept override {
+        execute_callback(on_switch_epoch_epoch_id_switched_store_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_switched_load() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_switched_load_callback);
+    }
+    void on_update_min_epoch_id_current_epoch_id_load() noexcept override {
+        execute_callback(on_update_min_epoch_id_current_epoch_id_load_callback);
+    }
+    void on_update_min_epoch_id_finished_epoch_id_load() noexcept override {
+        execute_callback(on_update_min_epoch_id_finished_epoch_id_load_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_to_be_recorded_load() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_to_be_recorded_load_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_to_be_recorded_cas() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_to_be_recorded_cas_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_record_finished_load() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_record_finished_load_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_informed_load_1() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_informed_load_1_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_informed_cas() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_informed_cas_callback);
+    }
+    void on_update_min_epoch_id_epoch_id_informed_load_2() noexcept override {
+        execute_callback(on_update_min_epoch_id_epoch_id_informed_load_2_callback);
+    }
+
+
 public:
-    // Callback functions for testing on_rotate_log_files to on_wait4 behavior.
-    // These can be dynamically assigned in each test case.
+    // Callback functions for testing various hooks in the datastore class.
+    // These functions can be dynamically assigned to customize behavior during testing of
+    // operations such as epoch management, log rotation, and session handling.
+    //
+    // Example usage:
+    // test_instance.on_end_session_finished_epoch_id_store_callback = []() {
+    //     std::cout << "Callback triggered for on_end_session_finished_epoch_id_store" << std::endl;
+    // };
     std::function<void()> on_rotate_log_files_callback;
+    std::function<void()> on_begin_session_current_epoch_id_store_callback;
+    std::function<void()> on_end_session_finished_epoch_id_store_callback;
+    std::function<void()> on_end_session_current_epoch_id_store_callback;
+    std::function<void()> on_switch_epoch_epoch_id_switched_store_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_switched_load_callback;
+    std::function<void()> on_update_min_epoch_id_current_epoch_id_load_callback;
+    std::function<void()> on_update_min_epoch_id_finished_epoch_id_load_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_to_be_recorded_load_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_to_be_recorded_cas_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_record_finished_load_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_informed_load_1_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_informed_cas_callback;
+    std::function<void()> on_update_min_epoch_id_epoch_id_informed_load_2_callback;
 };
 
 } // namespace limestone::api

--- a/test/test_root.h
+++ b/test/test_root.h
@@ -36,27 +36,15 @@ public:
     void rotate_epoch_file() { rotate_epoch_file_for_tests(); }
 
 protected:
-    // Overrides for on_wait1 to on_wait4 hooks to enable custom behavior during testing.
-    void on_wait1() override {
-        if (on_wait1_callback) on_wait1_callback();  // Executes the registered callback if set
-    }
-    void on_wait2() override {
-        if (on_wait2_callback) on_wait2_callback();
-    }
-    void on_wait3() override {
-        if (on_wait3_callback) on_wait3_callback();
-    }
-    void on_wait4() override {
-        if (on_wait4_callback) on_wait4_callback();
+    // Overrides for on_rotate_log_files to on_wait hooks to enable custom behavior during testing.
+    void on_rotate_log_files() override {
+        if (on_rotate_log_files_callback) on_rotate_log_files_callback();  // Executes the registered callback if set
     }
 
 public:
-    // Callback functions for testing on_wait1 to on_wait4 behavior.
+    // Callback functions for testing on_rotate_log_files to on_wait4 behavior.
     // These can be dynamically assigned in each test case.
-    std::function<void()> on_wait1_callback;
-    std::function<void()> on_wait2_callback;
-    std::function<void()> on_wait3_callback;
-    std::function<void()> on_wait4_callback;
+    std::function<void()> on_rotate_log_files_callback;
 };
 
 } // namespace limestone::api

--- a/test/test_root.h
+++ b/test/test_root.h
@@ -24,13 +24,14 @@ namespace limestone::api {
 
 class datastore_test : public datastore {
 public:
-    explicit datastore_test(configuration& conf) : datastore(conf) {}
+    explicit datastore_test(const configuration& conf) : datastore(conf) {}
     datastore_test() : datastore() {}
 
     // Provides access to internal members for testing purposes
     auto& log_channels() const noexcept { return log_channels_for_tests(); }
     auto epoch_id_informed() const noexcept { return epoch_id_informed_for_tests(); }
-    auto epoch_id_recorded() const noexcept { return epoch_id_recorded_for_tests(); }
+    auto epoch_id_to_be_recorded() const noexcept { return epoch_id_to_be_recorded_for_tests(); }
+    auto epoch_id_record_finished() const noexcept { return epoch_id_record_finished_for_tests(); }
     auto epoch_id_switched() const noexcept { return epoch_id_switched_for_tests(); }
     auto& files() const noexcept { return files_for_tests(); }
     void rotate_epoch_file() { rotate_epoch_file_for_tests(); }


### PR DESCRIPTION
Add test hooks and sample test cases for datastore and log_channel

Description:

* Added test hooks to the log_channel and datastore classes.
* Implemented a mechanism to inject test code into datastore_test using the test hooks.
* Created sample test cases using the test hooks:
    * race_detection_test.cpp for testing race conditions.
    * Supporting classes race_condition_test_manager.cpp and race_condition_test_manager.h added.

These changes enable more comprehensive testing for concurrency-related issues.