### PR TITLE
add getter methods to write_version_type

### DIFF
--- a/include/limestone/api/write_version_type.h
+++ b/include/limestone/api/write_version_type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Project Tsurugi.
+ * Copyright 2022-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ public:
         }
         return this->epoch_number_ < value.epoch_number_;
     }
+    [[nodiscard]] epoch_id_type get_major() const { return epoch_number_; }
+    [[nodiscard]] std::uint64_t get_minor() const { return minor_write_version_; }
 
 private:
     /**


### PR DESCRIPTION
`write_version_type` には メンバを取得する public なメソッドがありません。
(limestone モジュール内部の他クラスからのアクセスは friend 宣言でメンバ変数アクセスを許可しているようです)

先日 shirakami から limestone の `datastore::switch_available_boundary_version` メソッドの呼び出しに対するモックテストのようなものを作ろうとしましたが、
limestone 外部からでは `write_version_type` の中身にアクセスできないため、
正しく値が渡されているかの確認がテストコード上で自然な形で実現できません。
(先頭8バイトをキャストして読めばできなくはないですが)

そのため getter を追加しました。
(メソッド名については議論の余地があるとは思います)
