### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${package_name}
 
 set_target_properties(${package_name}
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 OUTPUT_NAME ${export_name}
 )
 
@@ -74,7 +74,7 @@ target_include_directories(dblogutil
 target_link_libraries(dblogutil PRIVATE limestone-impl PRIVATE glog::glog gflags::gflags)
 set_target_properties(dblogutil
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "tglogutil"
 )
 install_custom(dblogutil dblogutil)


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、起動時にファイルを見つけられず問題となります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。
