### PR TITLE
ci: remove build matrix and enable to specify os image via inputs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,7 +45,7 @@ jobs:
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
           cd build
-          ctest --verbose
+          ctest --verbose -j 16
 
       - name: Verify
         uses: project-tsurugi/tsurugi-annotations-action@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
         default: 'ubuntu-22.04'
 
 jobs:
-  Build:
+  Test:
     runs-on: [self-hosted, docker]
     permissions:
       checks: write
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DRECOVERY_SORTER_KVSLIB=ROCKSDB -DRECOVERY_SORTER_PUT_ONLY=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DRECOVERY_SORTER_KVSLIB=ROCKSDB -DRECOVERY_SORTER_PUT_ONLY=ON -DBUILD_TESTS=ON ..
           cmake --build . --target all --clean-first
 
       - name: CTest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,19 +1,22 @@
 name: Limestone-CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        default: 'ubuntu-22.04'
 
 jobs:
   Build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: [self-hosted, docker]
     permissions:
       checks: write
     timeout-minutes: 30
     container:
-      image: ghcr.io/project-tsurugi/tsurugi-ci:${{ matrix.os }}
+      image: ghcr.io/project-tsurugi/tsurugi-ci:${{ inputs.os || 'ubuntu-22.04' }}
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
     defaults:
@@ -21,7 +24,7 @@ jobs:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
-      CCACHE_DIR: ${{ vars.ccache_dir }}/${{ matrix.os }}
+      CCACHE_DIR: ${{ vars.ccache_dir }}/${{ inputs.os || 'ubuntu-22.04' }}
 
     steps:
       - name: Checkout
@@ -47,8 +50,6 @@ jobs:
       - name: Verify
         uses: project-tsurugi/tsurugi-annotations-action@v1
         if: always()
-        with:
-          matrix: ${{ toJson(matrix) }}
 
   Analysis:
     runs-on: [self-hosted, docker]


### PR DESCRIPTION
In this Pull Reuqest, the build matrix has been removed to change the configuration of the CI environment, and the build OS image can now be specified manually via inputs.
In addition, the number of parallels within each Step process has been adjusted, and minor improvements have been made to CI job names and CMake options.