### PR TITLE
cursor_impl: fix bug where remove_entry was ignored during validation

### DIFF
--- a/src/limestone/cursor_impl.cpp
+++ b/src/limestone/cursor_impl.cpp
@@ -146,7 +146,7 @@ bool cursor_impl::is_relevant_entry(const limestone::api::log_entry& entry) {
         return true;
 }
 
-bool cursor_impl::next() { // NOLINT(readability-function-cognitive-complexity)
+bool cursor_impl::next() { 
     while (true) {
         // Read from the snapshot stream if the snapshot_log_entry_ is empty
         if (!snapshot_log_entry_) {
@@ -181,12 +181,8 @@ bool cursor_impl::next() { // NOLINT(readability-function-cognitive-complexity)
                 compacted_log_entry_ = std::nullopt;
             } else {
                 // If key_sid is equal, snapshot is always newer by design
-                if (snapshot_log_entry_->type() == log_entry::entry_type::remove_entry) {
-                    // Deleted → skip both
-                    snapshot_log_entry_ = std::nullopt;
-                    compacted_log_entry_ = std::nullopt;
-                    continue;  // skip this entry
-                }
+                // Note: If snapshot contains a remove_entry, it will be filtered out 
+                // by the type check at the end of the method
                 log_entry_ = std::move(snapshot_log_entry_.value());
                 snapshot_log_entry_ = std::nullopt;
                 compacted_log_entry_ = std::nullopt;

--- a/src/limestone/cursor_impl.cpp
+++ b/src/limestone/cursor_impl.cpp
@@ -186,11 +186,10 @@ bool cursor_impl::next() {
                     snapshot_log_entry_ = std::nullopt;
                     compacted_log_entry_ = std::nullopt;
                     continue;  // skip this entry
-                } else {
-                    log_entry_ = std::move(snapshot_log_entry_.value());
-                    snapshot_log_entry_ = std::nullopt;
-                    compacted_log_entry_ = std::nullopt;
                 }
+                log_entry_ = std::move(snapshot_log_entry_.value());
+                snapshot_log_entry_ = std::nullopt;
+                compacted_log_entry_ = std::nullopt;
             }
         }
 

--- a/src/limestone/cursor_impl.cpp
+++ b/src/limestone/cursor_impl.cpp
@@ -82,7 +82,8 @@ void cursor_impl::validate_and_read_stream(std::optional<boost::filesystem::ifst
                     return;
                 }
             } while (log_entry->type() != log_entry::entry_type::normal_entry &&
-                     log_entry->type() != log_entry::entry_type::normal_with_blob);
+                     log_entry->type() != log_entry::entry_type::normal_with_blob 
+                     && log_entry->type() != log_entry::entry_type::remove_entry);
             // Check if the key_sid is in ascending order
             // TODO: Key order violation is detected here and the process is aborted.
             // However, this check should be moved to an earlier point, and if the key order is invalid,
@@ -112,6 +113,7 @@ void cursor_impl::validate_and_read_stream(std::optional<boost::filesystem::ifst
         log_entry = std::nullopt;
     }
 }
+
 
 bool cursor_impl::is_relevant_entry(const limestone::api::log_entry& entry) {
         // Step 1: Check if the entry is one of normal_entry, remove_entry, or normal_with_blob
@@ -178,20 +180,30 @@ bool cursor_impl::next() {
                 log_entry_ = std::move(compacted_log_entry_.value());
                 compacted_log_entry_ = std::nullopt;
             } else {
-                // If key_sid is equal, use snapshot_log_entry_, but reset both entries
-                log_entry_ = std::move(snapshot_log_entry_.value());
-                snapshot_log_entry_ = std::nullopt;
-                compacted_log_entry_ = std::nullopt;
+                // If key_sid is equal, snapshot is always newer by design
+                if (snapshot_log_entry_->type() == log_entry::entry_type::remove_entry) {
+                    // Deleted → skip both
+                    snapshot_log_entry_ = std::nullopt;
+                    compacted_log_entry_ = std::nullopt;
+                    continue;  // skip this entry
+                } else {
+                    log_entry_ = std::move(snapshot_log_entry_.value());
+                    snapshot_log_entry_ = std::nullopt;
+                    compacted_log_entry_ = std::nullopt;
+                }
             }
         }
+
         // Check if the current log_entry_ is a normal entry or normal_with_blob
         if (log_entry_.type() == log_entry::entry_type::normal_entry ||
             log_entry_.type() == log_entry::entry_type::normal_with_blob) {
             return true;
         }
+
         // If it's not a normal entry, continue the loop to skip it and read the next entry
     }
 }
+
 
 
 limestone::api::storage_id_type cursor_impl::storage() const noexcept {

--- a/src/limestone/cursor_impl.cpp
+++ b/src/limestone/cursor_impl.cpp
@@ -146,7 +146,7 @@ bool cursor_impl::is_relevant_entry(const limestone::api::log_entry& entry) {
         return true;
 }
 
-bool cursor_impl::next() {
+bool cursor_impl::next() { // NOLINT(readability-function-cognitive-complexity)
     while (true) {
         // Read from the snapshot stream if the snapshot_log_entry_ is empty
         if (!snapshot_log_entry_) {


### PR DESCRIPTION
This pull request enhances the functionality and robustness of the `cursor_impl` class in the Limestone project by adding support for a new log entry type (`remove_entry`) and improving the handling of log entries in various scenarios. It also introduces new test cases to ensure the correctness of the updated logic.

### Core functionality updates:
* Added support for a new log entry type, `remove_entry`, in the `cursor_impl` class. This includes updates to methods like `validate_and_read_stream` and `next` to correctly handle this new entry type. (`src/limestone/cursor_impl.cpp`: [[1]](diffhunk://#diff-988d990f7606d2c51643aba7ead8d24293a786b286be22fc5c762f4899031a42L85-R86) [[2]](diffhunk://#diff-988d990f7606d2c51643aba7ead8d24293a786b286be22fc5c762f4899031a42L181-R208)

### Test suite enhancements:
* Introduced new test cases in `cursor_impl_test` to verify the behavior of the `cursor_impl` class with different combinations of log entries, including:
  - Handling `normal_entry` in snapshot and compacted logs. (`test/limestone/snapshot/cursor_impl_test.cpp`: [test/limestone/snapshot/cursor_impl_test.cppR635-R728](diffhunk://#diff-a7dce5ce5ace0bb64ebd96b70c69ab60ff0468b330bc97165b26445bf1f1b711R635-R728))
  - Skipping `remove_entry` in snapshots. (`test/limestone/snapshot/cursor_impl_test.cpp`: [test/limestone/snapshot/cursor_impl_test.cppR635-R728](diffhunk://#diff-a7dce5ce5ace0bb64ebd96b70c69ab60ff0468b330bc97165b26445bf1f1b711R635-R728))
  - Ensuring `snapshot` entries override `compacted` entries when both are present. (`test/limestone/snapshot/cursor_impl_test.cpp`: [test/limestone/snapshot/cursor_impl_test.cppR635-R728](diffhunk://#diff-a7dce5ce5ace0bb64ebd96b70c69ab60ff0468b330bc97165b26445bf1f1b711R635-R728))
  - Ensuring `remove_entry` in snapshots overrides `normal_entry` in compacted logs. (`test/limestone/snapshot/cursor_impl_test.cpp`: [test/limestone/snapshot/cursor_impl_test.cppR635-R728](diffhunk://#diff-a7dce5ce5ace0bb64ebd96b70c69ab60ff0468b330bc97165b26445bf1f1b711R635-R728))

### Utility improvements:
* Added a helper method, `rename_pwal_to`, to facilitate renaming of log files in tests. (`test/limestone/snapshot/cursor_impl_test.cpp`: [test/limestone/snapshot/cursor_impl_test.cppR139-R148](diffhunk://#diff-a7dce5ce5ace0bb64ebd96b70c69ab60ff0468b330bc97165b26445bf1f1b711R139-R148))