### PR TITLE
fix: correctly handle entry type when updating sortdb (BLOB NULL/non-…

### DIFF
--- a/src/limestone/datastore_snapshot.cpp
+++ b/src/limestone/datastore_snapshot.cpp
@@ -66,7 +66,8 @@ void insert_entry_or_update_to_max(sortdb_wrapper* sortdb, const log_entry& e) {
     std::string value;
     if (sortdb->get(e.key_sid(), &value)) {
         write_version_type stored_write_version;
-        if (e.type() == log_entry::entry_type::normal_with_blob) {
+        auto stored_entry_type = static_cast<log_entry::entry_type>(value[0]);
+        if (stored_entry_type == log_entry::entry_type::normal_with_blob) {
             // For normal_with_blob, the stored format is:
             // [0]: entry_type, [1,8]: value_size, [9, ...]: value_etc (which starts with write_version)
             stored_write_version = write_version_type(value.substr(1 + sizeof(std::size_t)));


### PR DESCRIPTION
This pull request addresses a bug in how the entry type is determined during recovery in the `insert_entry_or_update_to_max` function, specifically when handling transitions between entries with and without BLOB data. The fix ensures that the stored entry type is read from the stored value, rather than using the incoming entry's type. Additionally, comprehensive tests are added to verify correct behavior when BLOB columns change between NULL and non-NULL states.

**Bug fix for entry type handling:**

* Updated `insert_entry_or_update_to_max` in `datastore_snapshot.cpp` to read the stored entry type from `value[0]` instead of using the new entry's type, ensuring correct format handling during recovery.

**Expanded test coverage for BLOB handling:**

* Added three new tests in `datastore_blob_test.cpp` to cover recovery scenarios:
  - Updating a BLOB column from NULL to non-NULL and verifying correct recovery.
  - Updating a BLOB column from non-NULL to NULL and verifying correct recovery.
  - Multiple alternating updates between NULL and non-NULL BLOB values to ensure robust handling.