### PR TITLE
add missing include (for FTBFS with gcc-15)

### DIFF
--- a/src/limestone/dblog_scan.h
+++ b/src/limestone/dblog_scan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 Project Tsurugi.
+ * Copyright 2024-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <boost/filesystem.hpp>
+#include <list>
 
 #include <limestone/api/datastore.h>
 #include "internal.h"


### PR DESCRIPTION
`<list>` の include が足りていない箇所があり g++-15 でコンパイルエラーになる問題の修正です。