### PR TITLE
feat: add generate_reference_tag replacing blob_pool

### DIFF
--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -272,6 +272,22 @@ public:
     [[nodiscard]] std::unique_ptr<blob_pool> acquire_blob_pool();
 
     /**
+     * @brief generates a BLOB reference tag for access control.
+     * @param blob_id the BLOB reference.
+     * @param transaction_id the transaction ID.
+     * @return the generated BLOB reference tag.
+     * @throws limestone_blob_exception if an internal error occurs during tag generation.
+     *         Possible reasons include:
+     *         - Environment issues (e.g., cryptographic library not initialized or misconfigured)
+     *         - Resource exhaustion (e.g., out of memory)
+     *         - Other unexpected internal errors
+     * @note No validation is performed for blob_id or transaction_id values; any value is accepted.
+     */
+    [[nodiscard]] blob_reference_tag_type generate_reference_tag(
+            blob_id_type blob_id,
+            std::uint64_t transaction_id);
+
+    /**
      * @brief returns BLOB file for the BLOB reference.
      * @param reference the target BLOB reference
      * @return the corresponding BLOB file

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -232,6 +232,12 @@ void datastore::persist_and_propagate_epoch_id(epoch_id_type epoch_id) {
     TRACE_END;
 }
 
+blob_reference_tag_type datastore::generate_reference_tag(
+        blob_id_type blob_id,
+        std::uint64_t transaction_id) {
+    return impl_->generate_reference_tag(blob_id, transaction_id);
+}
+
 void datastore::ready() {
     TRACE_START;
     try {

--- a/src/limestone/datastore_impl.h
+++ b/src/limestone/datastore_impl.h
@@ -108,9 +108,19 @@ public:
 
     /**
      * @brief gets the HMAC secret key for BLOB reference tag generation.
-     * @return reference to the HMAC secret key
+     * @return reference to the HMAC secret key.
      */
     [[nodiscard]] const std::array<std::uint8_t, 16>& get_hmac_secret_key() const noexcept;
+
+    /**
+     * @brief generates a BLOB reference tag for access control.
+     * @param blob_id the BLOB reference.
+     * @param transaction_id the transaction ID.
+     * @return the generated BLOB reference tag.
+     */
+    [[nodiscard]] blob_reference_tag_type generate_reference_tag(
+            blob_id_type blob_id,
+            std::uint64_t transaction_id) const;
 
 private:
     // Atomic counter for tracking active backup operations.

--- a/test/limestone/datastore_impl/datastore_impl_test.cpp
+++ b/test/limestone/datastore_impl/datastore_impl_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include "datastore_impl.h"
-#include "manifest.h"
+#include <limestone/datastore_impl.h>
+#include <limestone/manifest.h>
 
 namespace limestone::api {
 
@@ -63,6 +63,25 @@ TEST_F(datastore_impl_test, migration_info_multiple_sets) {
     EXPECT_TRUE(datastore.get_migration_info().has_value());
     EXPECT_EQ(datastore.get_migration_info().value().get_old_version(), 7);
     EXPECT_EQ(datastore.get_migration_info().value().get_new_version(), 8);
+}
+
+TEST_F(datastore_impl_test, generate_reference_tag_deterministic_and_unique) {
+    datastore_impl datastore;
+
+    blob_id_type const blob_id1 = 100;
+    blob_id_type const blob_id2 = 200;
+    std::uint64_t const txid1 = 1000;
+    std::uint64_t const txid2 = 2000;
+
+    auto const tag1a = datastore.generate_reference_tag(blob_id1, txid1);
+    auto const tag1b = datastore.generate_reference_tag(blob_id1, txid1);
+    EXPECT_EQ(tag1a, tag1b);
+
+    auto const tag2 = datastore.generate_reference_tag(blob_id2, txid1);
+    EXPECT_NE(tag1a, tag2);
+
+    auto const tag3 = datastore.generate_reference_tag(blob_id1, txid2);
+    EXPECT_NE(tag1a, tag3);
 }
 
 } // namespace limestone::api


### PR DESCRIPTION
This pull request introduces a new feature for generating deterministic and unique BLOB reference tags used for access control, along with the necessary implementation, API changes, and unit tests. It also improves code clarity by updating include directives to use angle brackets for consistency.

**New BLOB Reference Tag Generation Feature:**

* Added a new method `generate_reference_tag` to the `datastore` and `datastore_impl` classes, which generates a BLOB reference tag based on a given `blob_id` and `transaction_id`. The implementation uses HMAC-SHA256 with an internal secret key for tag generation and includes error handling for OpenSSL failures. [[1]](diffhunk://#diff-2d0ceb26e2770b6905c89bc9ea6d03e2e58244f1059c57e1c7dfd864591a3387R274-R289) [[2]](diffhunk://#diff-705aa9a8bb40751dc23a85149e26efd5f5de449a41eccc5eec22cd410686418bR235-R240) [[3]](diffhunk://#diff-ce26f92987ee288208c9dfdf8b0ddf954bbe5c37c96c76b0e172fe3c6e01d3e5L111-R124) [[4]](diffhunk://#diff-1a1024d2fc482c4628cb0074e36dac5b4f89911c81bcc55506b22a1b47ccd024R250-R298)

**Testing:**

* Introduced a new unit test `generate_reference_tag_deterministic_and_unique` in `datastore_impl_test.cpp` to verify that the generated tags are deterministic for the same inputs and unique for different combinations of `blob_id` and `transaction_id`.

**Codebase Consistency:**

* Updated include directives in `src/limestone/datastore_impl.cpp` and `test/limestone/datastore_impl/datastore_impl_test.cpp` to use angle brackets for all internal headers, improving consistency and clarity. [[1]](diffhunk://#diff-1a1024d2fc482c4628cb0074e36dac5b4f89911c81bcc55506b22a1b47ccd024L16-R33) [[2]](diffhunk://#diff-35596aac4c03be4269e62d356a4996922f3939c98da48aaeb9d678a91ae7114aL2-R3)