### PR TITLE
ci: improvement for utilization and optimization

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,7 +2,11 @@ name: Limestone-CI
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
     inputs:
       os:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,12 +63,19 @@ jobs:
       image: ghcr.io/project-tsurugi/tsurugi-ci:almalinux-latest
       volumes:
         - ${{ vars.ccache_dir }}:${{ vars.ccache_dir }}
+        - ${{ vars.ctcache_dir }}:${{ vars.ctcache_dir }}
     defaults:
       run:
         shell: bash
     env:
       CCACHE_CONFIGPATH: ${{ vars.ccache_dir }}/ccache.conf
       CCACHE_DIR: ${{ vars.ccache_dir }}/almalinux-latest
+
+      CTCACHE_DISABLE: ${{ vars.ctcache_disable }}
+      CTCACHE_DIR: ${{ vars.ctcache_dir }}/almalinux-latest
+      CTCACHE_SAVE_OUTPUT: 1
+      CTCACHE_LOCAL: 1
+
       CC: clang
       CXX: clang++
 
@@ -87,7 +94,7 @@ jobs:
 
       - name: Clang-Tidy
         run: |
-          python3 tools/bin/run-clang-tidy.py -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
+          python3 tools/bin/run-clang-tidy.py -clang-tidy-binary=/opt/ctcache/clang-tidy -quiet -export-fixes=build/clang-tidy-fix.yaml -p build -extra-arg=-Wno-unknown-warning-option -header-filter=$(pwd)'/(include|src)/.*\.h$' $(pwd)'/src/.*' 2>&1 | awk '!a[$0]++{print > "build/clang-tidy.log"}'
 
       # - id: Doxygen
       #   name: Doxygen


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve efficiency and enable caching for builds and static analysis. The main changes include ignoring markdown files in CI triggers, mounting cache volumes for build tools, setting up environment variables for caching, and specifying a custom `clang-tidy` binary.

**CI Trigger Optimization:**
- Updated the workflow triggers to ignore changes to markdown (`.md`) files, preventing unnecessary CI runs for documentation-only changes.

**Static Analysis Tooling:**
- Modified the `Clang-Tidy` step to use a custom `clang-tidy` binary located at `/opt/ctcache/clang-tidy` for potentially improved caching or performance.