### PR TITLE
eliminate unnecessary boost references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ find_package(glog REQUIRED)
 find_package(gflags REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost
-        COMPONENTS filesystem thread system container
+        COMPONENTS filesystem
         REQUIRED
         )
 if(${RECOVERY_SORTER_KVSLIB_UPPERCASE} STREQUAL "ROCKSDB")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,6 @@ target_link_libraries(${package_name}
         PUBLIC limestone-api
         PRIVATE Boost::boost
         PRIVATE Boost::filesystem
-        PRIVATE Boost::thread
-        PRIVATE Boost::container
         PRIVATE glog::glog
         PRIVATE ${sort_lib}
         PRIVATE nlohmann_json::nlohmann_json
@@ -61,8 +59,6 @@ target_link_libraries(limestone-impl
         INTERFACE ${package_name}
         INTERFACE Boost::boost
         INTERFACE Boost::filesystem
-        INTERFACE Boost::thread
-        INTERFACE Boost::container
         INTERFACE glog::glog
         INTERFACE ${sort_lib}
         INTERFACE nlohmann_json::nlohmann_json


### PR DESCRIPTION
CMakeLists.txtからBoostのthread system containerを除去するPRです。なお、filesystem は使っていました。
（経緯）https://github.com/project-tsurugi/tsurugi-issues/issues/1438#issuecomment-4029089848