### PR TITLE
Wip/deprecated api removal

### DIFF
--- a/include/limestone/api/configuration.h
+++ b/include/limestone/api/configuration.h
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include <vector>
-
 #include <boost/filesystem.hpp>
 
 namespace limestone::api {
@@ -38,31 +36,8 @@ public:
      */
     configuration() noexcept;
 
-    // TODO: When removing the deprecated constructors, drop metadata_location_ and
-    // replace data_locations_ with a single boost::filesystem::path field.
-    // TODO: Update direct data_locations_ accesses and migrate tests off the deprecated constructors.
     /**
-     * @brief create a object
-     * @param data_locations the list of data locations
-     * @param metadata_location the location of the metadata
-     * @deprecated use set_data_location() instead
-     */
-    configuration(
-        const std::vector<boost::filesystem::path>& data_locations,
-        boost::filesystem::path metadata_location) noexcept;
-
-    /**
-     * @brief create a object
-     * @param data_locations the list of data locations
-     * @param metadata_location the location of the metadata
-     * @deprecated use set_data_location() instead
-     */
-    configuration(
-        const std::vector<boost::filesystem::path>&& data_locations,
-        boost::filesystem::path metadata_location) noexcept;
-
-    /**
-     * @brief clear existing data locations and set a single data location
+     * @brief set a single data location
      * @param data_location the data location
      */
     void set_data_location(boost::filesystem::path data_location) noexcept;
@@ -72,14 +47,10 @@ public:
      * @brief setter for recover_max_parallelism
      * @param recover_max_parallelism  the number of recover_max_parallelism
      */
-    void set_recover_max_parallelism(int recover_max_parallelism) noexcept{
-        recover_max_parallelism_ = recover_max_parallelism;
-    }
+    void set_recover_max_parallelism(int recover_max_parallelism) noexcept;
 
 private:
-    std::vector<boost::filesystem::path> data_locations_{};
-
-    boost::filesystem::path metadata_location_{};
+    boost::filesystem::path data_location_{};
 
     int recover_max_parallelism_{default_recover_max_parallelism};
 

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -154,15 +154,6 @@ public:
      */
     log_channel& create_channel();
 
-    /**
-     * @brief create a log_channel to write logs to a file
-     * @details logs are written to separate files created for each channel
-     * @param location specifies the directory of the log files
-     * @return the reference of the log_channel
-     * @attention this function should be called before the ready() is called.
-     * @deprecated use create_channel() instead
-     */
-    log_channel& create_channel(const boost::filesystem::path& location);
 
     /**
      * @brief provide the largest epoch ID

--- a/include/limestone/api/datastore.h
+++ b/include/limestone/api/datastore.h
@@ -148,7 +148,8 @@ public:
 
     /**
      * @brief provide a log channel instance based on datastore state
-     * @details logs are written to separate files created for each channel
+     * @details logs are written to separate files created for each channel under the datastore's configured data location
+     *          (see configuration::set_data_location()).
      * @return the reference of the log_channel
      * @attention this function should be called before the ready() is called.
      */

--- a/sandbox/startup_speed_benchmark/startup_speed_benchmark.cpp
+++ b/sandbox/startup_speed_benchmark/startup_speed_benchmark.cpp
@@ -24,8 +24,8 @@ namespace {
     };
 
     BenchmarkResult measure_standard_cursor(const boost::filesystem::path& loc) {
-        std::vector<boost::filesystem::path> data_locations{loc};
-        limestone::api::configuration conf(data_locations, loc);
+        limestone::api::configuration conf{};
+        conf.set_data_location(loc);
 
         std::unique_ptr<limestone::api::datastore> ds = std::make_unique<limestone::api::datastore>(conf);
         ds->ready();
@@ -46,8 +46,8 @@ namespace {
     }
 
     BenchmarkResult measure_partitioned_cursor(const boost::filesystem::path& loc, std::size_t partition_count) {
-        std::vector<boost::filesystem::path> data_locations{loc};
-        limestone::api::configuration conf(data_locations, loc);
+        limestone::api::configuration conf{};
+        conf.set_data_location(loc);
 
         std::unique_ptr<limestone::api::datastore> ds = std::make_unique<limestone::api::datastore>(conf);
         ds->ready();

--- a/src/limestone/configuration.cpp
+++ b/src/limestone/configuration.cpp
@@ -19,27 +19,12 @@ namespace limestone::api {
 
 configuration::configuration() noexcept = default;
 
-configuration::configuration(
-    const std::vector<boost::filesystem::path>& data_locations,
-    boost::filesystem::path metadata_location) noexcept
-    : metadata_location_(std::move(metadata_location)) {
-    for (auto&& e : data_locations) {
-        data_locations_.emplace_back(e);
-    }
-}
-
-configuration::configuration(
-    const std::vector<boost::filesystem::path>&& data_locations,
-    boost::filesystem::path metadata_location) noexcept
-    : metadata_location_(std::move(metadata_location)) {
-    for (auto&& e : data_locations) {
-        data_locations_.emplace_back(e);
-    }
-}
-
 void configuration::set_data_location(boost::filesystem::path data_location) noexcept {
-    data_locations_.clear();
-    data_locations_.emplace_back(std::move(data_location));
+    data_location_ = std::move(data_location);
+}
+
+void configuration::set_recover_max_parallelism(int recover_max_parallelism) noexcept {
+    recover_max_parallelism_ = recover_max_parallelism;
 }
 
 } // namespace limestone::api

--- a/src/limestone/replication/log_channel_handler.cpp
+++ b/src/limestone/replication/log_channel_handler.cpp
@@ -42,11 +42,10 @@ validation_result log_channel_handler::validate_initial(std::unique_ptr<replicat
         return validation_result::error(3, "Failed to cast to message_log_channel_create");
     }
 
-    // TODO その他のバリデーション処理を入れる
+    // TODO Add other validation processes
 
-    auto& server = get_server();
     auto& ds = get_server().get_datastore();    
-    log_channel_ = &ds.create_channel(server.get_location());
+    log_channel_ = &ds.create_channel();
     
 
     // Perform additional validation as needed

--- a/src/limestone/replication/replica_server.cpp
+++ b/src/limestone/replication/replica_server.cpp
@@ -39,10 +39,8 @@ void replica_server::initialize(const boost::filesystem::path& location) {
         LOG_LP(FATAL) << "Error: Invalid location for replica server";
         throw limestone_exception(exception_type::initialization_failure, "Invalid location for replica server");
     }
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(location);
-    const boost::filesystem::path& metadata_location = location;
-    limestone::api::configuration conf(data_locations, metadata_location);
+    limestone::api::configuration conf{};
+    conf.set_data_location(location);
     datastore_ = std::make_unique<limestone::api::datastore>(conf);
     datastore_->get_impl()->set_replica_role();
 

--- a/src/limestone/replication/replica_server.cpp
+++ b/src/limestone/replication/replica_server.cpp
@@ -16,6 +16,7 @@
 
 #include "replica_server.h"
 
+#include <filesystem>
 #include <glog/logging.h>
 #include <limestone/logging.h>
 #include <netinet/tcp.h>

--- a/test/limestone/api/datastore_test.cpp
+++ b/test/limestone/api/datastore_test.cpp
@@ -10,7 +10,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/datastore_test/data_location";
-constexpr const char* metadata_location = "/tmp/datastore_test/metadata_location";
 constexpr const char* parent_directory = "/tmp/datastore_test";
 
 class datastore_test : public ::testing::Test {
@@ -86,14 +85,12 @@ TEST_F(datastore_test, add_persistent_callback_test) { // NOLINT
     if (system("rm -rf /tmp/datastore_test") != 0) {
         std::cerr << "cannot remove directory" << std::endl;
     }
-    if (system("mkdir -p /tmp/datastore_test/data_location /tmp/datastore_test/metadata_location") != 0) {
+    if (system("mkdir -p /tmp/datastore_test/data_location") != 0) {
         std::cerr << "cannot make directory" << std::endl;
     }
 
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(data_location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(data_location);
 
     datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
@@ -137,14 +134,12 @@ TEST_F(datastore_test, remove_persistent_callback_test) { // NOLINT
     if (system("rm -rf /tmp/datastore_test") != 0) {
         std::cerr << "cannot remove directory" << std::endl;
     }
-    if (system("mkdir -p /tmp/datastore_test/data_location /tmp/datastore_test/metadata_location") != 0) {
+    if (system("mkdir -p /tmp/datastore_test/data_location") != 0) {
         std::cerr << "cannot make directory" << std::endl;
     }
 
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(data_location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(data_location);
 
     datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
@@ -176,14 +171,12 @@ TEST_F(datastore_test, prevent_double_start_test) { // NOLINT
     if (system("rm -rf /tmp/datastore_test") != 0) {
         std::cerr << "cannot remove directory" << std::endl;
     }
-    if (system("mkdir -p /tmp/datastore_test/data_location /tmp/datastore_test/metadata_location") != 0) {
+    if (system("mkdir -p /tmp/datastore_test/data_location") != 0) {
         std::cerr << "cannot make directory" << std::endl;
     }
 
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(data_location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(data_location);
 
     auto ds1 = std::make_unique<limestone::api::datastore_test>(conf);
     ds1->ready();

--- a/test/limestone/api/log_and_recover_off_by_one_test.cpp
+++ b/test/limestone/api/log_and_recover_off_by_one_test.cpp
@@ -10,7 +10,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/log_and_recover_off_by_one_test/data_location";
-constexpr const char* metadata_location = "/tmp/log_and_recover_off_by_one_test/metadata_location";
 
 class log_and_recover_off_by_one_test : public ::testing::Test {
 public:
@@ -31,18 +30,16 @@ TEST_F(log_and_recover_off_by_one_test, log_and_recovery) {
     if (system("rm -rf /tmp/log_and_recover_off_by_one_test") != 0) {
         std::cerr << "cannot remove directory" << std::endl;
     }
-    if (system("mkdir -p /tmp/log_and_recover_off_by_one_test/data_location /tmp/log_and_recover_off_by_one_test/metadata_location") != 0) {
+    if (system("mkdir -p /tmp/log_and_recover_off_by_one_test/data_location") != 0) {
         std::cerr << "cannot make directory" << std::endl;
     }
 
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(data_location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(data_location);
 
     datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     // prepare durable epoch
     std::atomic<std::size_t> durable_epoch{0};

--- a/test/limestone/api/multiple_recover_test.cpp
+++ b/test/limestone/api/multiple_recover_test.cpp
@@ -10,7 +10,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/multiple_recover_test/data_location";
-constexpr const char* metadata_location = "/tmp/multiple_recover_test/metadata_location";
 
 class multiple_recover_test : public ::testing::Test {
 protected:
@@ -27,19 +26,17 @@ TEST_F(multiple_recover_test, two_recovery) {
     if (system("rm -rf /tmp/multiple_recover_test") != 0) {
         std::cerr << "cannot remove directory" << std::endl;
     }
-    if (system("mkdir -p /tmp/multiple_recover_test/data_location /tmp/multiple_recover_test/metadata_location") != 0) {
+    if (system("mkdir -p /tmp/multiple_recover_test/data_location") != 0) {
         std::cerr << "cannot make directory" << std::endl;
     }
 
     std::unique_ptr<limestone::api::datastore_test> datastore{};
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(data_location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(data_location);
 
     datastore = std::make_unique<limestone::api::datastore_test>(conf);
 
-    limestone::api::log_channel& channel = datastore->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore->create_channel();
 
     // prepare durable epoch
     std::atomic<std::size_t> durable_epoch{0};

--- a/test/limestone/blob/blob_file_garbage_collector_test.cpp
+++ b/test/limestone/blob/blob_file_garbage_collector_test.cpp
@@ -107,15 +107,13 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(base_directory);
-        boost::filesystem::path metadata_location_path{base_directory};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(base_directory);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
-        lc0_ = &datastore_->create_channel(base_directory);
-        lc1_ = &datastore_->create_channel(base_directory);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
         datastore_->ready();
     }
 

--- a/test/limestone/blob/blob_pool_impl_test.cpp
+++ b/test/limestone/blob/blob_pool_impl_test.cpp
@@ -73,10 +73,8 @@ protected:
             std::cerr << "Cannot create directory: " << dev_shm_test_directory_ << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(base_directory);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(base_directory);
 
         datastore_ = std::make_unique<limestone::api::datastore>(conf);
 

--- a/test/limestone/blob/datastore_blob_test.cpp
+++ b/test/limestone/blob/datastore_blob_test.cpp
@@ -15,7 +15,6 @@ using limestone::api::blob_id_type;
 using limestone::api::write_version_type;
 
 constexpr const char* data_location = "/tmp/datastore_blob_test/data_location";
-constexpr const char* metadata_location = "/tmp/datastore_blob_test/metadata_location";
 
 class datastore_blob_test : public ::testing::Test {
 protected:
@@ -33,7 +32,7 @@ protected:
         if (system("rm -rf /tmp/datastore_blob_test") != 0) {
             std::cerr << "cannot remove directory" << std::endl;
         }
-        if (system("mkdir -p /tmp/datastore_blob_test/data_location /tmp/datastore_blob_test/metadata_location") != 0) {
+        if (system("mkdir -p /tmp/datastore_blob_test/data_location") != 0) {
             std::cerr << "cannot make directory" << std::endl;
         }
 
@@ -48,16 +47,14 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(data_location);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(data_location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
-        lc0_ = &datastore_->create_channel(data_location);
-        lc1_ = &datastore_->create_channel(data_location);
-        lc2_ = &datastore_->create_channel(data_location);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
+        lc2_ = &datastore_->create_channel();
 
         datastore_->ready();
     }

--- a/test/limestone/compaction/compaction_test_fixture.h
+++ b/test/limestone/compaction/compaction_test_fixture.h
@@ -64,15 +64,13 @@ public:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
-        lc0_ = &datastore_->create_channel(location);
-        lc1_ = &datastore_->create_channel(location);
-        lc2_ = &datastore_->create_channel(location);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
+        lc2_ = &datastore_->create_channel();
 
         datastore_->ready();
         datastore_->wait_for_blob_file_garbace_collector();

--- a/test/limestone/epoch/callback_test.cpp
+++ b/test/limestone/epoch/callback_test.cpp
@@ -9,7 +9,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/callback_test/data_location";
-constexpr const char* metadata_location = "/tmp/callback_test/metadata_location";
 
 class callback_test : public ::testing::Test {
 protected:
@@ -17,14 +16,12 @@ protected:
         if (system("rm -rf /tmp/callback_test") != 0) {
             std::cerr << "cannot remove directory" << std::endl;
         }
-        if (system("mkdir -p /tmp/callback_test/data_location /tmp/callback_test/metadata_location") != 0) {
+        if (system("mkdir -p /tmp/callback_test/data_location") != 0) {
             std::cerr << "cannot make directory" << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(data_location);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(data_location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -49,7 +46,7 @@ void callback(limestone::api::epoch_id_type e) {
 
 
 TEST_F(callback_test, one_log_channel) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
     
     datastore_->add_persistent_callback(callback);
     datastore_->ready();
@@ -89,8 +86,8 @@ TEST_F(callback_test, one_log_channel) {
 }
 
 TEST_F(callback_test, log_channels) {
-    limestone::api::log_channel& channel1 = datastore_->create_channel(boost::filesystem::path(data_location));
-    limestone::api::log_channel& channel2 = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel1 = datastore_->create_channel();
+    limestone::api::log_channel& channel2 = datastore_->create_channel();
     
     datastore_->add_persistent_callback(callback);
     datastore_->ready();

--- a/test/limestone/epoch/epoch_file_test.cpp
+++ b/test/limestone/epoch/epoch_file_test.cpp
@@ -65,14 +65,12 @@ public:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
-        lc0_ = &datastore_->create_channel(location);
-        lc1_ = &datastore_->create_channel(location);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
     }
 
     epoch_id_type last_durable_epoch() {
@@ -383,5 +381,4 @@ TEST_F(epoch_file_test, remove_tmpe_epoch_file_on_boot) {
 
 
 } // namespace limestone::testing
-
 

--- a/test/limestone/epoch/finish_soon_test.cpp
+++ b/test/limestone/epoch/finish_soon_test.cpp
@@ -9,7 +9,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/finish_soon_test/data_location";
-constexpr const char* metadata_location = "/tmp/finish_soon_test/metadata_location";
 
 class finish_soon_test : public ::testing::Test {
 protected:
@@ -17,14 +16,12 @@ protected:
         if (system("rm -rf /tmp/finish_soon_test") != 0) {
             std::cerr << "cannot remove directory" << std::endl;
         }
-        if (system("mkdir -p /tmp/finish_soon_test/data_location /tmp/finish_soon_test/metadata_location") != 0) {
+        if (system("mkdir -p /tmp/finish_soon_test/data_location") != 0) {
             std::cerr << "cannot make directory" << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(data_location);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(data_location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -40,7 +37,7 @@ protected:
 };
 
 TEST_F(finish_soon_test, same) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
     
     datastore_->ready();
 
@@ -71,7 +68,7 @@ TEST_F(finish_soon_test, same) {
 }
 
 TEST_F(finish_soon_test, different) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
     
     datastore_->ready();
 

--- a/test/limestone/epoch/proceed_test.cpp
+++ b/test/limestone/epoch/proceed_test.cpp
@@ -9,7 +9,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/proceed_test/data_location";
-constexpr const char* metadata_location = "/tmp/proceed_test/metadata_location";
 
 class proceed_test : public ::testing::Test {
 protected:
@@ -17,14 +16,12 @@ protected:
         if (system("rm -rf /tmp/proceed_test") != 0) {
             std::cerr << "cannot remove directory" << std::endl;
         }
-        if (system("mkdir -p /tmp/proceed_test/data_location /tmp/proceed_test/metadata_location") != 0) {
+        if (system("mkdir -p /tmp/proceed_test/data_location") != 0) {
             std::cerr << "cannot make directory" << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(data_location);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(data_location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }

--- a/test/limestone/epoch/race_detection_test.cpp
+++ b/test/limestone/epoch/race_detection_test.cpp
@@ -255,14 +255,12 @@ public:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<my_datastore>(conf);
-        lc0_ = &datastore_->create_channel(location);
-        lc1_ = &datastore_->create_channel(location);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
     }
 
     void TearDown() {
@@ -439,5 +437,4 @@ TEST_F(race_detection_test, race_detection_behavior_test) {
 
 
 } // namespace limestone::testing
-
 

--- a/test/limestone/epoch/with_log_channel_test.cpp
+++ b/test/limestone/epoch/with_log_channel_test.cpp
@@ -9,7 +9,6 @@
 namespace limestone::testing {
 
 constexpr const char* data_location = "/tmp/with_log_channel_test/data_location";
-constexpr const char* metadata_location = "/tmp/with_log_channel_test/metadata_location";
 
 class with_log_channel_test : public ::testing::Test {
 protected:
@@ -17,14 +16,12 @@ protected:
         if (system("rm -rf /tmp/with_log_channel_test") != 0) {
             std::cerr << "cannot remove directory" << std::endl;
         }
-        if (system("mkdir -p /tmp/with_log_channel_test/data_location /tmp/with_log_channel_test/metadata_location") != 0) {
+        if (system("mkdir -p /tmp/with_log_channel_test/data_location") != 0) {
             std::cerr << "cannot make directory" << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(data_location);
-        boost::filesystem::path metadata_location_path{metadata_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(data_location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -40,7 +37,7 @@ protected:
 };
 
 TEST_F(with_log_channel_test, one_log_channel) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
     
     datastore_->ready();
 
@@ -69,8 +66,8 @@ TEST_F(with_log_channel_test, one_log_channel) {
 }
 
 TEST_F(with_log_channel_test, log_channels) {
-    limestone::api::log_channel& channel1 = datastore_->create_channel(boost::filesystem::path(data_location));
-    limestone::api::log_channel& channel2 = datastore_->create_channel(boost::filesystem::path(data_location));
+    limestone::api::log_channel& channel1 = datastore_->create_channel();
+    limestone::api::log_channel& channel2 = datastore_->create_channel();
     
     datastore_->ready();
 

--- a/test/limestone/log/durable_test.cpp
+++ b/test/limestone/log/durable_test.cpp
@@ -27,10 +27,8 @@ static constexpr const char* location = "/tmp/durable_test";
     }
 
     void regen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -50,8 +48,8 @@ TEST_F(durable_test, last_record_will_ignored) {
     using namespace limestone::api;
 
     datastore_->ready();
-    log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
-    log_channel& channel2 = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel = datastore_->create_channel();
+    log_channel& channel2 = datastore_->create_channel();
     datastore_->switch_epoch(42);
     channel.begin_session();
     channel.add_entry(3, "k1", "v1", {42, 4});
@@ -85,7 +83,7 @@ TEST_F(durable_test, invalidated_entries_are_never_reused) {
     using namespace limestone::api;
 
     datastore_->ready();
-    log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel = datastore_->create_channel();
     datastore_->switch_epoch(42);
     channel.begin_session();
     channel.add_entry(3, "k1", "v1", {42, 4});
@@ -118,7 +116,7 @@ TEST_F(durable_test, invalidated_entries_are_never_reused) {
     EXPECT_EQ(m["k1"], "v1");
     EXPECT_EQ(m["k2"], "v2");
 
-    log_channel& channel2 = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel2 = datastore_->create_channel();
     datastore_->switch_epoch(46);
     channel2.begin_session();
     channel2.add_entry(3, "k5", "v5", {46, 4});

--- a/test/limestone/log/log_channel_test.cpp
+++ b/test/limestone/log/log_channel_test.cpp
@@ -37,10 +37,8 @@ public:
             std::cerr << "cannot make directory" << std::endl;
         }
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -57,15 +55,15 @@ protected:
 };
 
 TEST_F(log_channel_test, name) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
     EXPECT_EQ(channel.file_path().string(), std::string(location) + "/pwal_0000");
 }
 
 TEST_F(log_channel_test, number_and_backup) {
-    limestone::api::log_channel& channel1 = datastore_->create_channel(boost::filesystem::path(location));
-    limestone::api::log_channel& channel2 = datastore_->create_channel(boost::filesystem::path(location));
-    limestone::api::log_channel& channel3 = datastore_->create_channel(boost::filesystem::path(location));
-    limestone::api::log_channel& channel4 = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel1 = datastore_->create_channel();
+    limestone::api::log_channel& channel2 = datastore_->create_channel();
+    limestone::api::log_channel& channel3 = datastore_->create_channel();
+    limestone::api::log_channel& channel4 = datastore_->create_channel();
 
     channel1.begin_session();
     channel2.begin_session();
@@ -119,7 +117,7 @@ static std::map<std::string, std::string> read_all_from_cursor(limestone::api::c
 }
 
 TEST_F(log_channel_test, remove) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_entry(42, "k1", "v1", {100, 4});
@@ -145,7 +143,7 @@ TEST_F(log_channel_test, remove) {
 TEST_F(log_channel_test, skip_storage_add_remove) {
     // write log entry but not use at the moment...
     // (purpose of this test: check not to abort as unimplemented)
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_storage(42, {90, 4});
@@ -172,7 +170,7 @@ TEST_F(log_channel_test, skip_storage_add_remove) {
 }
 
 TEST_F(log_channel_test, remove_storage) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_storage(42, {90, 4});
@@ -194,7 +192,7 @@ TEST_F(log_channel_test, remove_storage) {
 }
 
 TEST_F(log_channel_test, truncate_storage) {
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_storage(42, {90, 4});
@@ -231,7 +229,7 @@ TEST_F(log_channel_test, write_blob_entry) {
     const std::vector<limestone::api::blob_id_type> large_objects = {314, 1592, 65358};
 
 
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_entry(storage_id, key, value, write_version, large_objects);
@@ -265,7 +263,7 @@ TEST_F(log_channel_test, write_blob_entry_empty_large_objects) {
     const limestone::api::write_version_type write_version = limestone::api::write_version_type(67898, 76543);
     const std::vector<limestone::api::blob_id_type> large_objects = {};  // Empty large_objects
 
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     channel.begin_session();
     channel.add_entry(storage_id, key, value, write_version, large_objects);

--- a/test/limestone/log/log_dir_test.cpp
+++ b/test/limestone/log/log_dir_test.cpp
@@ -33,10 +33,8 @@ const boost::filesystem::path compaction_catalog_path = boost::filesystem::path(
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }

--- a/test/limestone/log/rotate_test.cpp
+++ b/test/limestone/log/rotate_test.cpp
@@ -43,10 +43,8 @@ public:
     }
 
     void regen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
         datastore_= nullptr;
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
@@ -106,8 +104,8 @@ extern std::string data_manifest(int persistent_format_version = 1);
 TEST_F(rotate_test, rotate_fails_with_io_error) {
     using namespace limestone::api;
     
-    log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
-    log_channel& unused_channel = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel = datastore_->create_channel();
+    log_channel& unused_channel = datastore_->create_channel();
     datastore_->switch_epoch(42);
     channel.begin_session();
     channel.add_entry(42, "k1", "v1", {100, 4});
@@ -144,8 +142,8 @@ TEST_F(rotate_test, log_is_rotated) { // NOLINT
     using namespace limestone::api;
     datastore_->ready();
 
-    log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
-    log_channel& unused_channel = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel = datastore_->create_channel();
+    log_channel& unused_channel = datastore_->create_channel();
 
     datastore_->switch_epoch(42);
     channel.begin_session();
@@ -255,9 +253,9 @@ TEST_F(rotate_test, inactive_files_are_also_backed_up) { // NOLINT
     //    DATA LOST if step f. is wrong
 
     {
-        log_channel& channel1_0 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0000
-        log_channel& channel1_1 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0001
-        log_channel& unused_1_2 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0002 unused
+        log_channel& channel1_0 = datastore_->create_channel();  // pwal_0000
+        log_channel& channel1_1 = datastore_->create_channel();  // pwal_0001
+        log_channel& unused_1_2 = datastore_->create_channel();  // pwal_0002 unused
         datastore_->ready();
         datastore_->switch_epoch(42);
         channel1_0.begin_session();
@@ -271,9 +269,9 @@ TEST_F(rotate_test, inactive_files_are_also_backed_up) { // NOLINT
     }
     regen_datastore();
     {
-        log_channel& channel2_0 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0000
-        log_channel& unused_2_1 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0001 unused
-        log_channel& unused_2_2 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0002 unused
+        log_channel& channel2_0 = datastore_->create_channel();  // pwal_0000
+        log_channel& unused_2_1 = datastore_->create_channel();  // pwal_0001 unused
+        log_channel& unused_2_2 = datastore_->create_channel();  // pwal_0002 unused
         datastore_->ready();
         datastore_->switch_epoch(44);
         channel2_0.begin_session();
@@ -446,8 +444,8 @@ TEST_F(rotate_test, get_snapshot_works) { // NOLINT
     using namespace limestone::api;
 
     datastore_->ready();
-    log_channel& channel = datastore_->create_channel(boost::filesystem::path(location));
-    log_channel& unused_channel = datastore_->create_channel(boost::filesystem::path(location));
+    log_channel& channel = datastore_->create_channel();
+    log_channel& unused_channel = datastore_->create_channel();
     datastore_->switch_epoch(42);
     channel.begin_session();
     channel.add_entry(3, "k1", "v1", {100, 4});
@@ -571,9 +569,9 @@ TEST_F(rotate_test, restore_file_set_entries_with_blob) {
 
     // Step 1: Setup log channels, write log entries, and register a BLOB file.
     {
-        log_channel& channel1_0 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0000
-        log_channel& channel1_1 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0001
-        log_channel& unused_1_2 = datastore_->create_channel(boost::filesystem::path(location));   // pwal_0002 unused
+        log_channel& channel1_0 = datastore_->create_channel();  // pwal_0000
+        log_channel& channel1_1 = datastore_->create_channel();  // pwal_0001
+        log_channel& unused_1_2 = datastore_->create_channel();   // pwal_0002 unused
 
         datastore_->ready();
         datastore_->switch_epoch(42);
@@ -599,9 +597,9 @@ TEST_F(rotate_test, restore_file_set_entries_with_blob) {
     // Step 2: Simulate server restart with fewer channels.
     regen_datastore();
     {
-        log_channel& channel2_0 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0000
-        log_channel& unused_2_1 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0001 unused
-        log_channel& unused_2_2 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0002 unused
+        log_channel& channel2_0 = datastore_->create_channel();  // pwal_0000
+        log_channel& unused_2_1 = datastore_->create_channel();  // pwal_0001 unused
+        log_channel& unused_2_2 = datastore_->create_channel();  // pwal_0002 unused
 
         datastore_->ready();
         datastore_->switch_epoch(44);
@@ -703,9 +701,9 @@ TEST_F(rotate_test, restore_from_directory_with_blob) {
 
     // Step 1: Setup log channels, write log entries, and register a BLOB file.
     {
-        log_channel& channel1_0 = datastore_->create_channel(boost::filesystem::path(location)); // pwal_0000
-        log_channel& channel1_1 = datastore_->create_channel(boost::filesystem::path(location)); // pwal_0001
-        log_channel& unused_1_2 = datastore_->create_channel(boost::filesystem::path(location));  // pwal_0002 (unused)
+        log_channel& channel1_0 = datastore_->create_channel(); // pwal_0000
+        log_channel& channel1_1 = datastore_->create_channel(); // pwal_0001
+        log_channel& unused_1_2 = datastore_->create_channel();  // pwal_0002 (unused)
 
         datastore_->ready();
         datastore_->switch_epoch(42);
@@ -734,9 +732,9 @@ TEST_F(rotate_test, restore_from_directory_with_blob) {
     // Step 2: Simulate server restart with fewer channels.
     regen_datastore();
     {
-        log_channel& channel2_0 = datastore_->create_channel(boost::filesystem::path(location)); // pwal_0000
-        log_channel& unused_2_1 = datastore_->create_channel(boost::filesystem::path(location)); // pwal_0001 (unused)
-        log_channel& unused_2_2 = datastore_->create_channel(boost::filesystem::path(location)); // pwal_0002 (unused)
+        log_channel& channel2_0 = datastore_->create_channel(); // pwal_0000
+        log_channel& unused_2_1 = datastore_->create_channel(); // pwal_0001 (unused)
+        log_channel& unused_2_2 = datastore_->create_channel(); // pwal_0002 (unused)
 
         datastore_->ready();
         datastore_->switch_epoch(44);

--- a/test/limestone/replication/blob_socket_io_test.cpp
+++ b/test/limestone/replication/blob_socket_io_test.cpp
@@ -26,10 +26,8 @@ protected:
         [[maybe_unused]] int rm_result = system(("rm -rf " + std::string(base_directory)).c_str());
         [[maybe_unused]] int mkdir_result = system(("mkdir -p " + std::string(base_directory)).c_str());
 
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(base_directory);
-        boost::filesystem::path metadata_location_path{base_directory};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(base_directory);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);        
     }

--- a/test/limestone/replication/datastore_replication_test.cpp
+++ b/test/limestone/replication/datastore_replication_test.cpp
@@ -60,15 +60,13 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(master);
-        boost::filesystem::path metadata_location_path{master};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(master);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
-        lc0_ = &datastore_->create_channel(master);
-        lc1_ = &datastore_->create_channel(master);
+        lc0_ = &datastore_->create_channel();
+        lc1_ = &datastore_->create_channel();
     }
 
     void start_replica_server(uint16_t port) {

--- a/test/limestone/replication/handler_resources_test.cpp
+++ b/test/limestone/replication/handler_resources_test.cpp
@@ -22,7 +22,7 @@ TEST_F(handler_resources_test, returns_correct_server_and_channel) {
     replica_server server{};
     server.initialize(base_location);
     auto& ds = server.get_datastore();
-    auto& channel = ds.create_channel(base_location);
+    auto& channel = ds.create_channel();
     socket_io io("");
 
     log_channel_handler_resources resources{io, channel};

--- a/test/limestone/replication/log_channel_replication_test.cpp
+++ b/test/limestone/replication/log_channel_replication_test.cpp
@@ -89,14 +89,12 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(master);
-        boost::filesystem::path metadata_location_path{master};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(master);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
 
-        log_channel_ = &datastore_->create_channel(master);
+        log_channel_ = &datastore_->create_channel();
     }
 
     void start_replica_server(uint16_t port) {
@@ -164,7 +162,7 @@ private:
 TEST_F(log_channel_replication_test, replica_connector_setter_getter) {
     unsetenv("TSURUGI_REPLICATION_ENDPOINT");
     gen_datastore();
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(master));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     EXPECT_EQ(channel.get_impl()->get_replica_connector(), nullptr);
 
@@ -177,7 +175,7 @@ TEST_F(log_channel_replication_test, replica_connector_setter_getter) {
 TEST_F(log_channel_replication_test, replica_connector_disable) {
     unsetenv("TSURUGI_REPLICATION_ENDPOINT");
     gen_datastore();
-    limestone::api::log_channel& channel = datastore_->create_channel(boost::filesystem::path(master));
+    limestone::api::log_channel& channel = datastore_->create_channel();
 
     auto connector = std::make_unique<limestone::replication::replica_connector>();
     channel.get_impl()->set_replica_connector(std::move(connector));

--- a/test/limestone/replication/message_group_commit_test.cpp
+++ b/test/limestone/replication/message_group_commit_test.cpp
@@ -18,10 +18,8 @@ protected:
     void SetUp() override {
         boost::filesystem::remove_all(base_location);
         boost::filesystem::create_directories(base_location);
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(base_location);
-        boost::filesystem::path metadata_location_path{base_location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(base_location);
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
     }
 

--- a/test/limestone/replication/message_log_entries_test.cpp
+++ b/test/limestone/replication/message_log_entries_test.cpp
@@ -32,10 +32,8 @@ protected:
         boost::filesystem::remove_all(base_location);
         boost::filesystem::create_directories(base_location);
         
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(replica);
-        boost::filesystem::path metadata_location_path{replica};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(replica);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);        
     }
@@ -340,7 +338,7 @@ TEST_F(message_log_entries_test, receiving_blob_entry_with_socket_io_should_fail
 }
 
 TEST_F(message_log_entries_test, post_receive) {
-    auto& lc = datastore_->create_channel(replica);
+    auto& lc = datastore_->create_channel();
     datastore_->ready();
     socket_io io("");
     log_channel_handler_resources resources(io, lc);
@@ -376,10 +374,8 @@ TEST_F(message_log_entries_test, post_receive) {
 
 TEST_F(message_log_entries_test, write_all_entry_type_to_pwal_via_replication_channel) {
     // Setup datastore for master(client)
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(master);
-    boost::filesystem::path metadata_location_path{master};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(master);
     auto ds = std::make_unique<limestone::api::datastore_test>(conf);
 
     // Stop the datastore_ created in SetUp because it conflicts with the replica server

--- a/test/limestone/replication/replica_connector_test.cpp
+++ b/test/limestone/replication/replica_connector_test.cpp
@@ -173,10 +173,8 @@ TEST_F(replica_connector_test, connect_to_server_with_blob_support) {
         // No need to close listen_fd here, as it's shared and managed by the server thread
     });
 
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(base_directory);
-    boost::filesystem::path metadata_location_path{base_directory};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(base_directory);
     auto ds = std::make_unique<limestone::api::datastore_test>(conf);
 
 

--- a/test/limestone/replication/scenario_test.cpp
+++ b/test/limestone/replication/scenario_test.cpp
@@ -150,15 +150,13 @@ protected:
     }
 
     void gen_datastore(const char* location) {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location_path{location};
-        limestone::api::configuration conf(data_locations, metadata_location_path);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         ds = std::make_unique<limestone::api::datastore_test>(conf);
 
-        lc0_ = &ds->create_channel(location);
-        lc1_ = &ds->create_channel(location);
+        lc0_ = &ds->create_channel();
+        lc1_ = &ds->create_channel();
         ds->ready();
     }
 

--- a/test/limestone/snapshot/cursor_impl_test.cpp
+++ b/test/limestone/snapshot/cursor_impl_test.cpp
@@ -112,13 +112,11 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{};
-        data_locations.emplace_back(location);
-        boost::filesystem::path metadata_location{location};
-        limestone::api::configuration conf(data_locations, metadata_location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
-        lc0_ = &datastore_->create_channel(location);
+        lc0_ = &datastore_->create_channel();
 
         datastore_->ready();
     }

--- a/test/limestone/snapshot/snapshot_impl_test.cpp
+++ b/test/limestone/snapshot/snapshot_impl_test.cpp
@@ -35,11 +35,11 @@ protected:
     }
 
     void gen_datastore() {
-        std::vector<boost::filesystem::path> data_locations{ location };
-        limestone::api::configuration conf(data_locations, location);
+        limestone::api::configuration conf{};
+        conf.set_data_location(location);
 
         datastore_ = std::make_unique<limestone::api::datastore_test>(conf);
-        lc0_ = &datastore_->create_channel(location);
+        lc0_ = &datastore_->create_channel();
         datastore_->ready();
     }
 

--- a/test/limestone/utils/dblogutil_test.cpp
+++ b/test/limestone/utils/dblogutil_test.cpp
@@ -36,7 +36,6 @@ int invoke(const std::string& command, std::string& out) {
 class dblogutil_test : public ::testing::Test {
 public:
 static constexpr const char* location = "/tmp/dblogutil_test";
-static constexpr const char* metadata_location = "/tmp/dblogutil_test/metadata";
 
     void SetUp() {
         boost::filesystem::remove_all(location);
@@ -580,10 +579,8 @@ TEST_F(dblogutil_test, execution_fails_while_active_datastore) {
     EXPECT_NE(out.find("\n" "status: OK"), out.npos);
 
     // Activate datastore
-    std::vector<boost::filesystem::path> data_locations{};
-    data_locations.emplace_back(location);
-    boost::filesystem::path metadata_location_path{metadata_location};
-    limestone::api::configuration conf(data_locations, metadata_location_path);
+    limestone::api::configuration conf{};
+    conf.set_data_location(location);
     auto ds1 = std::make_unique<limestone::api::datastore_test>(conf);
     ds1->ready();
 


### PR DESCRIPTION
This pull request simplifies the configuration and log channel creation APIs in the Limestone project by removing deprecated multi-location and metadata location support. The changes consolidate data location handling to a single field, update all usage to the new API, and remove obsolete constructors and methods. Tests and benchmarks are updated accordingly.

**API Simplification and Cleanup:**

* Removed deprecated constructors from `configuration` that accepted multiple data locations and a metadata location, consolidating to a single `data_location_` field and updating the setter to use `std::filesystem::path` (`include/limestone/api/configuration.h`, `src/limestone/configuration.cpp`). [[1]](diffhunk://#diff-3257726851e1ff34a32f51440e5cf9c76007c5b482f1f5f3dc61abf9c2c613f8L44-R45) [[2]](diffhunk://#diff-3257726851e1ff34a32f51440e5cf9c76007c5b482f1f5f3dc61abf9c2c613f8L89-R69) [[3]](diffhunk://#diff-7466af868b6a95e19274f3bd8e1690f479f6228e24870dafce0a76106a8072a2L22-R27)
* Removed the deprecated `create_channel(const boost::filesystem::path&)` method from `datastore`, leaving only the simplified `create_channel()` (`include/limestone/api/datastore.h`, `src/limestone/datastore.cpp`). [[1]](diffhunk://#diff-2d0ceb26e2770b6905c89bc9ea6d03e2e58244f1059c57e1c7dfd864591a3387L157-L165) [[2]](diffhunk://#diff-705aa9a8bb40751dc23a85149e26efd5f5de449a41eccc5eec22cd410686418bL397-L417)
* Updated all usages of the configuration API in benchmarks, replication, and tests to use the new single-location approach and removed references to metadata locations (`sandbox/startup_speed_benchmark/startup_speed_benchmark.cpp`, `src/limestone/replication/replica_server.cpp`, `test/limestone/api/altimeter_wal_started_log_test.cpp`, `test/limestone/api/datastore_test.cpp`, `test/limestone/api/log_and_recover_off_by_one_test.cpp`). [[1]](diffhunk://#diff-fae8bfcbfeb044ec16ca24aab09ecdc42eea0118af4cd668eea6f7cbbb319598L27-R29) [[2]](diffhunk://#diff-fae8bfcbfeb044ec16ca24aab09ecdc42eea0118af4cd668eea6f7cbbb319598L49-R51) [[3]](diffhunk://#diff-803e8eaa5b22b93ee9a59185fdf01c4a2e6f28b18b682c7d86ef8446ec56c9fdL42-R43) [[4]](diffhunk://#diff-e554f7e0c7da854eda4ffbcb2b0b04f69fe9d71a31fbbd9753dce4afae26797bL78-R83) [[5]](diffhunk://#diff-e554f7e0c7da854eda4ffbcb2b0b04f69fe9d71a31fbbd9753dce4afae26797bL110-R112) [[6]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L155-R159) [[7]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L206-R208) [[8]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L245-R245) [[9]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L274-R272) [[10]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L300-R296) [[11]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L331-R325) [[12]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L365-R357) [[13]](diffhunk://#diff-47bc15ce84f367e03daef76554678e28c96cd99849b8fd616917bc57da64f1e8L13) [[14]](diffhunk://#diff-6457b25c26e42edff8bcfc4e8996878fa61e3b7f4ce20ff5a73898fd399fe783L24)

**Internal Refactoring:**

* Updated the implementation of `datastore` and `configuration` to use the new single data location field and removed all logic related to multiple locations and metadata location. [[1]](diffhunk://#diff-705aa9a8bb40751dc23a85149e26efd5f5de449a41eccc5eec22cd410686418bL95-R95) [[2]](diffhunk://#diff-7466af868b6a95e19274f3bd8e1690f479f6228e24870dafce0a76106a8072a2L22-R27)

**Replication and Logging:**

* Updated log channel creation in replication logic to use the simplified API (`src/limestone/replication/log_channel_handler.cpp`).

These changes streamline the API, reduce complexity, and make the configuration process more robust and easier to use.