### PR TITLE
fix: resolve undefined behavior surfaced by Ubuntu 26.04 unit tests

### DIFF
--- a/src/limestone/datastore_snapshot.cpp
+++ b/src/limestone/datastore_snapshot.cpp
@@ -200,12 +200,40 @@ write_version_type extract_write_version(const std::string_view& db_key) {
     return write_version_type{wv};
 }
 
+/**
+ * @brief Reconstruct a snapshot value from a sortdb key/value pair.
+ *
+ * Byte layouts:
+ *   db_key   = [ write_version (write_version_size bytes) ][ original key ]
+ *   db_value = [ entry_type (1 byte) ][ payload ]
+ *   result   = [ write_version (write_version_size bytes) ][ payload ]
+ *
+ * The write_version is copied from the head of db_key (byte-swapped), and the
+ * payload is db_value with its leading entry_type byte removed. The entry_type
+ * is consumed separately by the caller, so it is intentionally dropped here.
+ *
+ * @param db_key   sortdb key: write_version followed by the original key.
+ * @param db_value sortdb value: a 1-byte entry_type followed by the payload.
+ * @return snapshot value: write_version followed by the payload.
+ */
 [[maybe_unused]]
 std::string create_value_from_db_key_and_value(const std::string_view& db_key, const std::string_view& db_value) {
+    // Preconditions: db_key must contain a full write_version, and db_value must
+    // contain at least the entry_type byte. Violations indicate corrupted data.
+    if (db_key.size() < write_version_size) {
+        THROW_LIMESTONE_EXCEPTION("db_key is too short to contain write_version");
+    }
+    if (db_value.empty()) {
+        THROW_LIMESTONE_EXCEPTION("db_value is empty; entry_type byte is missing");
+    }
     std::string value(write_version_size + db_value.size() - 1, '\0');
     store_bswap64_value(&value[0], &db_key[0]);  // NOLINT(readability-container-data-pointer)
     store_bswap64_value(&value[8], &db_key[8]);
-    std::memcpy(&value[write_version_size], &db_value[1], db_value.size() - 1);
+    // remove_entry carries no payload (db_value is the entry_type byte only),
+    // so there is nothing to copy when db_value.size() == 1.
+    if (db_value.size() > 1) {
+        std::memcpy(&value[write_version_size], &db_value[1], db_value.size() - 1);
+    }
     return value;
 }
 

--- a/src/limestone/replication/replica_server.h
+++ b/src/limestone/replication/replica_server.h
@@ -86,7 +86,11 @@ public:
     void clear_handlers() noexcept;
 
     /**
-     * Signal the accept_loop() to exit and close the listening socket.
+     * @brief Shut down the server and release the datastore.
+     *
+     * Signal accept_loop() to exit, close the listening socket, and release the
+     * datastore (including its manifest lock). To run the server again
+     * afterwards, call initialize() before start_listener().
      */
     void shutdown();
 

--- a/test/limestone/replication/log_channel_handler_test.cpp
+++ b/test/limestone/replication/log_channel_handler_test.cpp
@@ -14,6 +14,7 @@
 #include "rdma/rdma_replication_message_io.h"
 #include "rdma/rdma_send_stream_base.h"
 #include <boost/filesystem.hpp>
+#include <algorithm>
 #include <chrono>
 #include <cerrno>
 #include <cstdint>

--- a/test/limestone/replication/opened_blob_file_test.cpp
+++ b/test/limestone/replication/opened_blob_file_test.cpp
@@ -82,7 +82,7 @@ TEST_F(opened_blob_file_test, open_for_send_rejects_directory) {
     boost::filesystem::path path = blob.path();
     boost::filesystem::create_directories(path);
 
-    EXPECT_THROW(opened_blob_file::open_for_send(*datastore_, blob_id), std::runtime_error);
+    EXPECT_THROW((void)opened_blob_file::open_for_send(*datastore_, blob_id), std::runtime_error);
 }
 
 TEST_F(opened_blob_file_test, read_blob_chunk_reads_exact_bytes) {

--- a/test/limestone/replication/rdma_log_entries_receiver_test.cpp
+++ b/test/limestone/replication/rdma_log_entries_receiver_test.cpp
@@ -303,7 +303,7 @@ TEST(rdma_log_entries_receiver_test, rejects_non_log_entry_message_type) {
 
     rdma_log_entries_receiver receiver{receiver_datastore};
     std::string bytes(1, static_cast<char>(message_type_id::COMMON_ACK));
-    EXPECT_THROW([[maybe_unused]] std::size_t consumed = receiver.consume(bytes), std::runtime_error);
+    EXPECT_THROW((void)receiver.consume(bytes), std::runtime_error);
     EXPECT_FALSE(receiver.has_message());
     EXPECT_FALSE(receiver.reading_message());
 
@@ -319,7 +319,7 @@ TEST(rdma_log_entries_receiver_test, take_message_without_completed_message_thro
     limestone::api::datastore_test receiver_datastore{receiver_conf};
 
     rdma_log_entries_receiver receiver{receiver_datastore};
-    EXPECT_THROW(receiver.take_message(), std::logic_error);
+    EXPECT_THROW((void)receiver.take_message(), std::logic_error);
 
     boost::filesystem::remove_all(receiver_location);
 }

--- a/test/limestone/replication/replica_server_test.cpp
+++ b/test/limestone/replication/replica_server_test.cpp
@@ -298,6 +298,9 @@ TEST_F(replica_server_test, listener_restart_multiple_times) {
     server.shutdown();
     accept_thread.join();
 
+    // shutdown() releases the datastore, so re-initialize before restarting.
+    server.initialize(location1);
+
     // Restart listener for the second time
     ASSERT_TRUE(server.start_listener(addr));
 


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1437

Ubuntu 26.04's libstdc++ enables _GLIBCXX_ASSERTIONS in -O0 builds, which turns long-standing latent UB into runtime aborts. These are real bugs, not tool false positives.

- datastore_snapshot: guard create_value_from_db_key_and_value against out-of-range access. Require db_key to hold a full write_version and db_value to hold at least the entry_type byte; remove_entry carries no payload, so skip the payload copy when db_value has only the type byte. This prevents the size_t underflow in the value size calculation and the OOB reads (&db_key[8], &db_value[1]).
- replica_server: add @brief to shutdown() and document it as terminal teardown that also releases the datastore (including its manifest lock).
- test(replica_server): call initialize() before restart, since shutdown() now releases the datastore.
- test(log_channel_handler): include <algorithm> for std::search after the removal of a transitive include in newer libstdc++.
- test(opened_blob_file, rdma_log_entries_receiver): discard nodiscard return values inside EXPECT_THROW via (void) to silence -Wunused-result.