### PR TITLE
fix(compaction): update compaction catalog on offline compaction (tsurugi-issues #1498)

### DIFF
--- a/src/limestone/compaction_catalog.cpp
+++ b/src/limestone/compaction_catalog.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <glog/logging.h>
+#include <algorithm>
 #include <fstream>
 #include <stdexcept>
 #include <sstream>
@@ -180,9 +181,12 @@ void compaction_catalog::parse_catalog_entry(const std::string& line, bool& max_
 
 // Method to update the compaction catalog
 void compaction_catalog::update_catalog_file(epoch_id_type max_epoch_id, blob_id_type max_blob_id, const std::set<compacted_file_info>& compacted_files, const std::set<std::string>& detached_pwals) {
-    // Update internal state
+    // Update internal state. The maximum blob ID is a monotonically non-decreasing
+    // high-water mark: blob IDs must never be reused, so it must not drop below the
+    // value already recorded even when the caller passes a smaller value (e.g. a
+    // compaction that observed only the blobs still referenced by live entries).
     max_epoch_id_ = max_epoch_id;
-    max_blob_id_ = max_blob_id;
+    max_blob_id_ = std::max(max_blob_id, max_blob_id_);
     compacted_files_ = compacted_files;
     detached_pwals_ = detached_pwals;
 

--- a/src/limestone/compaction_catalog.h
+++ b/src/limestone/compaction_catalog.h
@@ -137,8 +137,15 @@ public:
      * This method updates the catalog with new compacted files, detached PWALs, the maximum epoch ID,
      * and the maximum blob ID, then writes the updated catalog to a file.
      * 
+     * The maximum blob ID is monotonically non-decreasing: the recorded value never
+     * drops below the value the catalog already holds, even if @p max_blob_id is
+     * smaller. Blob IDs must never be reused, so a compaction (online or offline)
+     * that observes only the blobs still referenced by live entries must not lower
+     * this high-water mark.
+     *
      * @param max_epoch_id The maximum epoch ID to be recorded in the catalog.
-     * @param max_blob_id The maximum blob ID to be recorded in the catalog.
+     * @param max_blob_id The candidate maximum blob ID; the recorded value is the
+     *                    maximum of this and the current value (see above).
      * @param compacted_files Set of compacted files to be included in the catalog.
      * @param detached_pwals Set of detached PWALs to be included in the catalog.
      */
@@ -179,6 +186,13 @@ public:
      * @return The filename of the compaction catalog.
      */
     [[nodiscard]] static inline std::string get_catalog_filename() { return COMPACTION_CATALOG_FILENAME; }
+
+    /**
+     * @brief Returns the filename of the compaction catalog backup.
+     *
+     * @return The filename of the compaction catalog backup.
+     */
+    [[nodiscard]] static inline std::string get_catalog_backup_filename() { return COMPACTION_CATALOG_BACKUP_FILENAME; }
 
     /**
      * @brief Retrieves the name of the compaction temporary directory.

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -1014,9 +1014,11 @@ void datastore::compact_with_online() {
 
 
     // update compaction catalog
+    // update_catalog_file keeps max_blob_id monotonically non-decreasing, so the
+    // high-water mark recorded by previous compactions is preserved even though
+    // max_blob_id here reflects only the freshly compacted files.
     compacted_file_info compacted_file_info{compacted_file.filename().string(), 1};
     detached_pwals.erase(compacted_file.filename().string());
-    max_blob_id = std::max(max_blob_id, compaction_catalog_->get_max_blob_id());
     compaction_catalog_->update_catalog_file(result.get_epoch_id(), max_blob_id, {compacted_file_info}, detached_pwals);
     add_file(compacted_file);
 

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -146,6 +146,44 @@ datastore::datastore(configuration const& conf) : location_(conf.data_location_)
         add_file(compaction_catalog_path);
         compaction_catalog_ = std::make_unique<compaction_catalog>(compaction_catalog::from_catalog_file(location_));
 
+        // Verify consistency between the compaction catalog and the WAL files.
+        // The compacted file is loaded at startup based purely on its presence on
+        // disk (see snapshot_impl). If it exists but is not registered in the
+        // catalog, the snapshot would be generated as if no compaction had been
+        // performed, dropping remove entries and resurrecting deleted records
+        // (see tsurugi-issues #1498). Fail fast instead of silently corrupting data.
+        // NOTE: only the single well-known compacted file is checked here. If
+        // multiple compacted files are ever registered, this check must be extended.
+        {
+            boost::filesystem::path compacted_file_path = location_ / compaction_catalog::get_compacted_filename();
+            // Use the error_code overload so that a filesystem error (permission, broken
+            // symlink, I/O error, ...) is funneled into a limestone_exception rather than
+            // escaping as a boost::filesystem::filesystem_error.
+            bool compacted_file_exists = boost::filesystem::exists(compacted_file_path, error);
+            if (error) {
+                std::string err_msg = "failed to check existence of the compacted file '"
+                    + compacted_file_path.string() + "': " + error.message();
+                LOG(ERROR) << "/:limestone:config:datastore " << err_msg;
+                throw limestone_exception(exception_type::initialization_failure, err_msg);
+            }
+            if (compacted_file_exists) {
+                bool registered = false;
+                for (auto const& info : compaction_catalog_->get_compacted_files()) {
+                    if (info.get_file_name() == compaction_catalog::get_compacted_filename()) {
+                        registered = true;
+                        break;
+                    }
+                }
+                if (!registered) {
+                    std::string err_msg = "compaction catalog is inconsistent: the compacted file '"
+                        + compaction_catalog::get_compacted_filename()
+                        + "' exists but is not registered in the catalog, log directory: " + location_.string();
+                    LOG(ERROR) << "/:limestone:config:datastore " << err_msg;
+                    throw limestone_exception(exception_type::initialization_failure, err_msg);
+                }
+            }
+        }
+
         epoch_file_path_ = location_ / std::string(limestone::internal::epoch_file_name);
         tmp_epoch_file_path_ = location_ / std::string(limestone::internal::tmp_epoch_file_name);
         const bool result = boost::filesystem::exists(epoch_file_path_, error);

--- a/src/limestone/datastore.cpp
+++ b/src/limestone/datastore.cpp
@@ -156,13 +156,16 @@ datastore::datastore(configuration const& conf) : location_(conf.data_location_)
         // multiple compacted files are ever registered, this check must be extended.
         {
             boost::filesystem::path compacted_file_path = location_ / compaction_catalog::get_compacted_filename();
-            // Use the error_code overload so that a filesystem error (permission, broken
-            // symlink, I/O error, ...) is funneled into a limestone_exception rather than
-            // escaping as a boost::filesystem::filesystem_error.
-            bool compacted_file_exists = boost::filesystem::exists(compacted_file_path, error);
-            if (error) {
+            // Use the error_code overload so that a genuine filesystem error (permission,
+            // broken symlink, I/O error, ...) is funneled into a limestone_exception rather
+            // than escaping as a boost::filesystem::filesystem_error. A non-existent file is
+            // the normal case: boost::filesystem::exists reports it via error_code as ENOENT,
+            // so that condition must be excluded and must not be treated as an error.
+            boost::system::error_code exists_error;
+            bool compacted_file_exists = boost::filesystem::exists(compacted_file_path, exists_error);
+            if (exists_error && exists_error != boost::system::errc::no_such_file_or_directory) {
                 std::string err_msg = "failed to check existence of the compacted file '"
-                    + compacted_file_path.string() + "': " + error.message();
+                    + compacted_file_path.string() + "': " + exists_error.message();
                 LOG(ERROR) << "/:limestone:config:datastore " << err_msg;
                 throw limestone_exception(exception_type::initialization_failure, err_msg);
             }

--- a/src/limestone/dblogutil/dblogutil.cpp
+++ b/src/limestone/dblogutil/dblogutil.cpp
@@ -182,6 +182,56 @@ boost::filesystem::path make_backup_dir_next_to(const boost::filesystem::path& t
     return make_tmp_dir_next_to(target_dir, ".backup_XXXXXX");
 }
 
+// Carry over the existing compaction catalog (and its backup) from from_dir into the
+// work directory tmp, then register the freshly produced compacted file. tmp will
+// replace from_dir, so carrying over the catalog preserves the high-water marks
+// recorded by previous compactions: update_catalog_file keeps max_blob_id
+// monotonically non-decreasing, so the freshly computed value (which reflects only
+// blobs still referenced by live entries) never lowers it and blob IDs are never
+// reused. If from_dir has no catalog (a directory that was never compacted), the empty
+// catalog created by setup_initial_logdir(tmp) is used instead.
+void carry_over_and_update_compaction_catalog(boost::filesystem::path const& from_dir, boost::filesystem::path const& tmp,
+                                              epoch_id_type ld_epoch, blob_id_type max_blob_id) {
+    auto copy_catalog_file = [&](const std::string& filename) {
+        boost::filesystem::path src = from_dir / filename;
+        boost::system::error_code ec;
+        bool present = boost::filesystem::exists(src, ec);
+        // A non-existent file is the normal case (boost reports it via ec as ENOENT).
+        // Any other error (permission, I/O, ...) must not be silently ignored: skipping
+        // the copy would drop the catalog carry-over and let later processing run on an
+        // inconsistent state.
+        if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+            LOG_AND_THROW_IO_EXCEPTION("failed to check existence of compaction catalog file: " + src.string(), ec);
+        }
+        if (present) {
+            boost::filesystem::copy_file(src, tmp / filename, boost::filesystem::copy_options::overwrite_existing, ec);
+            if (ec) {
+                LOG_AND_THROW_IO_EXCEPTION("failed to copy compaction catalog file: " + src.string(), ec);
+            }
+        }
+    };
+    copy_catalog_file(compaction_catalog::get_catalog_filename());
+    copy_catalog_file(compaction_catalog::get_catalog_backup_filename());
+
+    VLOG_LP(log_info) << "updating compaction catalog in " << tmp;
+    // tmp always has a catalog here (setup_initial_logdir created an empty one, possibly
+    // overwritten by the carry-over above), so loading only fails when the carried-over
+    // catalog and its backup are both unreadable. In that case abort with a clear message
+    // rather than silently proceeding, which would lose the blob-id high-water mark.
+    compaction_catalog catalog = [&]() {
+        try {
+            return compaction_catalog::from_catalog_file(tmp);
+        } catch (const limestone_exception& ex) {
+            LOG_AND_THROW_EXCEPTION(
+                "the existing compaction catalog in " + from_dir.string() +
+                " is unreadable and could not be recovered; offline compaction was aborted to"
+                " avoid losing the blob-id high-water mark (cause: " + ex.what() + ")");
+        }
+    }();
+    compacted_file_info compacted_file{compaction_catalog::get_compacted_filename(), 1};
+    catalog.update_catalog_file(ld_epoch, max_blob_id, {compacted_file}, {});
+}
+
 void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
     epoch_id_type ld_epoch{};
     if (epoch.has_value()) {
@@ -252,53 +302,7 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
     // Without this, a subsequent startup treats the directory as if no compaction
     // had been performed, and remove entries are dropped from the snapshot,
     // resurrecting deleted records (see tsurugi-issues #1498).
-    //
-    // tmp will replace from_dir, so carry over the existing catalog (and its backup)
-    // before updating it, exactly like online compaction updates the live catalog.
-    // This preserves the high-water marks recorded by previous compactions: in
-    // particular update_catalog_file keeps max_blob_id monotonically non-decreasing,
-    // so the freshly computed max_blob_id (which reflects only blobs still referenced
-    // by live entries) never lowers it and blob IDs are never reused. If from_dir has
-    // no catalog (a directory that was never compacted), the empty catalog created by
-    // setup_initial_logdir(tmp) is used instead.
-    auto copy_catalog_file = [&](const std::string& filename) {
-        boost::filesystem::path src = from_dir / filename;
-        boost::system::error_code ec;
-        bool present = boost::filesystem::exists(src, ec);
-        // A non-existent file is the normal case (boost reports it via ec as ENOENT).
-        // Any other error (permission, I/O, ...) must not be silently ignored: skipping
-        // the copy would drop the catalog carry-over and let later processing run on an
-        // inconsistent state.
-        if (ec && ec != boost::system::errc::no_such_file_or_directory) {
-            LOG_AND_THROW_IO_EXCEPTION("failed to check existence of compaction catalog file: " + src.string(), ec);
-        }
-        if (present) {
-            boost::filesystem::copy_file(src, tmp / filename, boost::filesystem::copy_options::overwrite_existing, ec);
-            if (ec) {
-                LOG_AND_THROW_IO_EXCEPTION("failed to copy compaction catalog file: " + src.string(), ec);
-            }
-        }
-    };
-    copy_catalog_file(compaction_catalog::get_catalog_filename());
-    copy_catalog_file(compaction_catalog::get_catalog_backup_filename());
-
-    VLOG_LP(log_info) << "updating compaction catalog in " << tmp;
-    // tmp always has a catalog here (setup_initial_logdir created an empty one, possibly
-    // overwritten by the carry-over above), so loading only fails when the carried-over
-    // catalog and its backup are both unreadable. In that case abort with a clear message
-    // rather than silently proceeding, which would lose the blob-id high-water mark.
-    compaction_catalog catalog = [&]() {
-        try {
-            return compaction_catalog::from_catalog_file(tmp);
-        } catch (const limestone_exception& ex) {
-            LOG_AND_THROW_EXCEPTION(
-                "the existing compaction catalog in " + from_dir.string() +
-                " is unreadable and could not be recovered; offline compaction was aborted to"
-                " avoid losing the blob-id high-water mark (cause: " + ex.what() + ")");
-        }
-    }();
-    compacted_file_info compacted_file{compaction_catalog::get_compacted_filename(), 1};
-    catalog.update_catalog_file(ld_epoch, max_blob_id, {compacted_file}, {});
+    carry_over_and_update_compaction_catalog(from_dir, tmp, ld_epoch, max_blob_id);
 
     if (FLAGS_dry_run) {
         std::cout << "compaction will be successfully completed (dry-run mode)" << std::endl;

--- a/src/limestone/dblogutil/dblogutil.cpp
+++ b/src/limestone/dblogutil/dblogutil.cpp
@@ -26,6 +26,7 @@
 #include "log_entry.h"
 #include "limestone_exception_helper.h"
 #include "manifest.h"
+#include "compaction_catalog.h"
 
 // NOLINTBEGIN(performance-avoid-endl)
 
@@ -227,7 +228,7 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
 
     VLOG_LP(log_info) << "making compact pwal file to " << tmp;
     compaction_options options{from_dir, tmp, FLAGS_thread_num};
-    create_compact_pwal_and_get_max_blob_id(options);
+    blob_id_type max_blob_id = create_compact_pwal_and_get_max_blob_id(options);
 
     // epoch file
     VLOG_LP(log_info) << "making compact epoch file to " << tmp;
@@ -246,6 +247,15 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
     if (fclose(strm) != 0) {  // NOLINT(*-owning-memory)
         LOG_AND_THROW_IO_EXCEPTION("fclose failed", errno);
     }
+
+    // Update the compaction catalog so that the compacted file is registered.
+    // Without this, a subsequent startup treats the directory as if no compaction
+    // had been performed, and remove entries are dropped from the snapshot,
+    // resurrecting deleted records (see tsurugi-issues #1498).
+    VLOG_LP(log_info) << "updating compaction catalog in " << tmp;
+    compaction_catalog catalog{tmp};
+    compacted_file_info compacted_file{compaction_catalog::get_compacted_filename(), 1};
+    catalog.update_catalog_file(ld_epoch, max_blob_id, {compacted_file}, {});
 
     if (FLAGS_dry_run) {
         std::cout << "compaction will be successfully completed (dry-run mode)" << std::endl;

--- a/src/limestone/dblogutil/dblogutil.cpp
+++ b/src/limestone/dblogutil/dblogutil.cpp
@@ -252,8 +252,51 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
     // Without this, a subsequent startup treats the directory as if no compaction
     // had been performed, and remove entries are dropped from the snapshot,
     // resurrecting deleted records (see tsurugi-issues #1498).
+    //
+    // tmp will replace from_dir, so carry over the existing catalog (and its backup)
+    // before updating it, exactly like online compaction updates the live catalog.
+    // This preserves the high-water marks recorded by previous compactions: in
+    // particular update_catalog_file keeps max_blob_id monotonically non-decreasing,
+    // so the freshly computed max_blob_id (which reflects only blobs still referenced
+    // by live entries) never lowers it and blob IDs are never reused. If from_dir has
+    // no catalog (a directory that was never compacted), the empty catalog created by
+    // setup_initial_logdir(tmp) is used instead.
+    auto copy_catalog_file = [&](const std::string& filename) {
+        boost::filesystem::path src = from_dir / filename;
+        boost::system::error_code ec;
+        bool present = boost::filesystem::exists(src, ec);
+        // A non-existent file is the normal case (boost reports it via ec as ENOENT).
+        // Any other error (permission, I/O, ...) must not be silently ignored: skipping
+        // the copy would drop the catalog carry-over and let later processing run on an
+        // inconsistent state.
+        if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+            LOG_AND_THROW_IO_EXCEPTION("failed to check existence of compaction catalog file: " + src.string(), ec);
+        }
+        if (present) {
+            boost::filesystem::copy_file(src, tmp / filename, boost::filesystem::copy_options::overwrite_existing, ec);
+            if (ec) {
+                LOG_AND_THROW_IO_EXCEPTION("failed to copy compaction catalog file: " + src.string(), ec);
+            }
+        }
+    };
+    copy_catalog_file(compaction_catalog::get_catalog_filename());
+    copy_catalog_file(compaction_catalog::get_catalog_backup_filename());
+
     VLOG_LP(log_info) << "updating compaction catalog in " << tmp;
-    compaction_catalog catalog{tmp};
+    // tmp always has a catalog here (setup_initial_logdir created an empty one, possibly
+    // overwritten by the carry-over above), so loading only fails when the carried-over
+    // catalog and its backup are both unreadable. In that case abort with a clear message
+    // rather than silently proceeding, which would lose the blob-id high-water mark.
+    compaction_catalog catalog = [&]() {
+        try {
+            return compaction_catalog::from_catalog_file(tmp);
+        } catch (const limestone_exception& ex) {
+            LOG_AND_THROW_EXCEPTION(
+                "the existing compaction catalog in " + from_dir.string() +
+                " is unreadable and could not be recovered; offline compaction was aborted to"
+                " avoid losing the blob-id high-water mark (cause: " + ex.what() + ")");
+        }
+    }();
     compacted_file_info compacted_file{compaction_catalog::get_compacted_filename(), 1};
     catalog.update_catalog_file(ld_epoch, max_blob_id, {compacted_file}, {});
 

--- a/test/limestone/compaction/compaction_catalog_test.cpp
+++ b/test/limestone/compaction/compaction_catalog_test.cpp
@@ -873,6 +873,31 @@ TEST_F(compaction_catalog_test, restore_from_backup_exceptions) {
         limestone_io_exception);
 }
 
+// Verifies that max_blob_id is a monotonically non-decreasing high-water mark:
+// update_catalog_file must never lower it (blob IDs must never be reused), while
+// max_epoch_id is set directly.
+TEST_F(compaction_catalog_test, max_blob_id_is_monotonically_non_decreasing) {
+    compaction_catalog catalog(test_dir);
+
+    catalog.update_catalog_file(10, 1000, {}, {});
+    EXPECT_EQ(catalog.get_max_blob_id(), 1000);
+    EXPECT_EQ(catalog.get_max_epoch_id(), 10);
+
+    // A smaller value must not lower the high-water mark.
+    catalog.update_catalog_file(20, 500, {}, {});
+    EXPECT_EQ(catalog.get_max_blob_id(), 1000);
+    EXPECT_EQ(catalog.get_max_epoch_id(), 20);  // epoch is set directly, not maxed
+
+    // A larger value updates it.
+    catalog.update_catalog_file(30, 2000, {}, {});
+    EXPECT_EQ(catalog.get_max_blob_id(), 2000);
+
+    // The preserved value survives a reload from the catalog file.
+    compaction_catalog reloaded = compaction_catalog::from_catalog_file(test_dir);
+    EXPECT_EQ(reloaded.get_max_blob_id(), 2000);
+    EXPECT_EQ(reloaded.get_max_epoch_id(), 30);
+}
+
 
 
 }  // namespace limestone::testing

--- a/test/limestone/compaction/compaction_test.cpp
+++ b/test/limestone/compaction/compaction_test.cpp
@@ -46,7 +46,6 @@ TEST_F(compaction_test, no_pwals) {
 }
 
 TEST_F(compaction_test, scenario01) {
-    FLAGS_v = 50;
 
     gen_datastore();
     datastore_->switch_epoch(1);
@@ -624,7 +623,6 @@ TEST_F(compaction_test, scenario02) {
 
 // This test case verifies the correct behavior of `remove_entry`.
 TEST_F(compaction_test, scenario03) {
-    FLAGS_v = 50;  // set VLOG level to 50
 
     // 1. Create multiple PWALs using two different storage IDs
     gen_datastore();
@@ -774,7 +772,6 @@ TEST_F(compaction_test, scenario03) {
 
 // This test case verifies the correct behavior of `remove_storage`.
 TEST_F(compaction_test, scenario04) {
-    FLAGS_v = 50;  // set VLOG level to 50
 
     gen_datastore();
     datastore_->switch_epoch(1);
@@ -967,7 +964,6 @@ TEST_F(compaction_test, scenario04) {
 
 // This test case verifies the correct behavior of blob feature.
 TEST_F(compaction_test, scenario_blob) {
-    FLAGS_v = 50;  // set VLOG level to 50
 
     gen_datastore();
     datastore_->switch_epoch(1);

--- a/test/limestone/compaction/compaction_test_fixture.h
+++ b/test/limestone/compaction/compaction_test_fixture.h
@@ -48,9 +48,12 @@ extern const std::string_view data_nondurable;
 
 class compaction_test : public ::testing::Test {
 public:
-    // Non-static so that derived fixtures can use a distinct directory; sharing one
-    // directory across separate test suites causes a race when ctest runs them in
-    // parallel. Derived fixtures may override this in their constructor.
+    compaction_test() = default;
+    // Derived fixtures pass a distinct directory through this constructor so that the
+    // dependent paths below are derived from the actual location. Sharing one directory
+    // across separate test suites causes a race when ctest runs them in parallel.
+    explicit compaction_test(const char* location) : location(location) {}
+
     const char* location = "/tmp/compaction_test";
     const boost::filesystem::path manifest_path = boost::filesystem::path(location) / std::string(limestone::internal::manifest::file_name);
     const boost::filesystem::path compaction_catalog_path = boost::filesystem::path(location) / "compaction_catalog";

--- a/test/limestone/compaction/compaction_test_fixture.h
+++ b/test/limestone/compaction/compaction_test_fixture.h
@@ -48,7 +48,10 @@ extern const std::string_view data_nondurable;
 
 class compaction_test : public ::testing::Test {
 public:
-    static constexpr const char* location = "/tmp/compaction_test";
+    // Non-static so that derived fixtures can use a distinct directory; sharing one
+    // directory across separate test suites causes a race when ctest runs them in
+    // parallel. Derived fixtures may override this in their constructor.
+    const char* location = "/tmp/compaction_test";
     const boost::filesystem::path manifest_path = boost::filesystem::path(location) / std::string(limestone::internal::manifest::file_name);
     const boost::filesystem::path compaction_catalog_path = boost::filesystem::path(location) / "compaction_catalog";
     const std::string compacted_filename = compaction_catalog::get_compacted_filename();

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -174,7 +174,7 @@ TEST_F(offline_compaction_test, detects_inconsistent_compaction_catalog_at_start
     // Startup must fail fast because the catalog is inconsistent. Verify both that a
     // limestone_exception is thrown and that its message is the intended one (so that an
     // unrelated failure that happens to throw the same type is not mistaken for success).
-    // TODO: replace this placeholder with the actual message once the detection is implemented.
+    // This substring must match the message produced by datastore startup.
     const std::string expected_message_substr = "compaction catalog is inconsistent";
     try {
         gen_datastore();

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <limestone/api/limestone_exception.h>
+
+#include "compaction_test_fixture.h"
+
+namespace limestone::testing {
+
+using namespace std::literals;
+using namespace limestone::api;
+using namespace limestone::internal;
+
+// Test fixture for offline compaction (tglogutil compaction). It reuses the
+// datastore-based helpers of compaction_test and adds a helper to drive the
+// external tglogutil binary, so that the whole offline-compaction round trip
+// (datastore -> shutdown -> offline compaction -> restart) can be exercised.
+class offline_compaction_test : public compaction_test {
+public:
+    // Path to the offline compaction utility (tglogutil), relative to the test
+    // executable's working directory. This matches the convention used by
+    // dblogutil_compaction_test.
+    static constexpr char const* util_command = "../src/tglogutil";
+
+    // Invoke an external command and capture its combined output.
+    static int invoke(const std::string& command, std::string& out) {
+        FILE* fp = popen(command.c_str(), "r");
+        if (fp == nullptr) {
+            out = std::string("popen failed: ") + strerror(errno);
+            return -1;
+        }
+        std::array<char, 4096> buf{};
+        std::ostringstream ss;
+        std::size_t rc = 0;
+        while ((rc = fread(buf.data(), 1, buf.size() - 1, fp)) > 0) {
+            ss.write(buf.data(), static_cast<std::streamsize>(rc));
+        }
+        out.assign(ss.str());
+        LOG(INFO) << "\n" << out;
+        return pclose(fp);
+    }
+
+    // Run offline compaction on the test location via the tglogutil binary.
+    void run_offline_compaction() {
+        std::string out;
+        std::string command = std::string(util_command) + " compaction --force " + std::string(location) + " 2>&1";
+        int rc = invoke(command, out);
+        ASSERT_EQ(rc, 0) << "invoke failed: " << out;
+        ASSERT_TRUE(out.find("compaction was successfully completed: ") != std::string::npos)
+            << "tglogutil output:\n" << out;
+    }
+};
+
+// Reproduces tsurugi-issues #1498.
+//
+// After offline compaction, the compaction catalog must register the compacted
+// file. Otherwise, a later restart that needs to apply remove entries (e.g. a
+// deleted record) generates a snapshot that drops the remove entries, and the
+// deleted record stored in pwal_0000.compacted is resurrected.
+TEST_F(offline_compaction_test, preserves_remove_entries_after_restart) {
+
+    // 1. Create initial records and shut down the datastore.
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "A", "va", {1, 0});
+    lc0_->add_entry(1, "B", "vb", {1, 1});
+    lc0_->add_entry(1, "C", "vc", {1, 2});
+    lc0_->end_session();
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // 2. Perform offline compaction with the tglogutil binary.
+    run_offline_compaction();
+
+    // The compaction catalog must register the compacted file (this is the fix
+    // for #1498; without it, get_compacted_files() is empty).
+    {
+        compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+        const std::set<compacted_file_info>& compacted_files = catalog.get_compacted_files();
+        // The catalog must register exactly one compacted file: pwal_0000.compacted (version 1).
+        // Use EXPECT (not ASSERT) so that the end-to-end snapshot checks below still run
+        // even if this catalog check fails, which is what actually reproduces the field issue.
+        EXPECT_EQ(compacted_files.size(), 1);
+        if (!compacted_files.empty()) {
+            const compacted_file_info& info = *compacted_files.begin();
+            EXPECT_EQ(info.get_file_name(), compacted_filename);
+            EXPECT_EQ(info.get_version(), 1);
+        }
+    }
+    ASSERT_TRUE(boost::filesystem::exists(boost::filesystem::path(location) / compacted_filename));
+
+    // 3. Restart, delete record "B" (emits a remove entry), and shut down.
+    gen_datastore();
+    datastore_->switch_epoch(3);
+    lc0_->begin_session();
+    lc0_->remove_entry(1, "B", {3, 0});
+    lc0_->end_session();
+    datastore_->switch_epoch(4);
+
+    // 4. Restart and read the snapshot. "B" must stay deleted; "A" and "C" must
+    //    remain. With the bug, "B" is resurrected from pwal_0000.compacted.
+    std::vector<std::pair<std::string, std::string>> kv_list = restart_datastore_and_read_snapshot();
+
+    std::map<std::string, std::string> kv;
+    for (const auto& [key, value] : kv_list) {
+        kv.emplace(key, value);
+    }
+
+    EXPECT_EQ(kv.size(), 2);
+    EXPECT_EQ(kv.count("B"), 0u);  // must not be resurrected
+    ASSERT_EQ(kv.count("A"), 1u);
+    ASSERT_EQ(kv.count("C"), 1u);
+    EXPECT_EQ(kv["A"], "va");
+    EXPECT_EQ(kv["C"], "vc");
+}
+
+// Verifies that startup fails fast when the compaction catalog is inconsistent
+// with the WAL files: the compacted file exists on disk but is not registered in
+// the catalog (the broken state produced by the #1498 bug).
+TEST_F(offline_compaction_test, detects_inconsistent_compaction_catalog_at_startup) {
+
+    // Produce a valid compacted file and catalog via online compaction.
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "A", "va", {1, 0});
+    lc0_->end_session();
+    datastore_->switch_epoch(2);
+    run_compact_with_epoch_switch(3);
+
+    boost::filesystem::path compacted_path = boost::filesystem::path(location) / compacted_filename;
+    ASSERT_TRUE(boost::filesystem::exists(compacted_path));
+    {
+        compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+        ASSERT_EQ(catalog.get_compacted_files().size(), 1);
+    }
+
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // Corrupt the catalog: drop the compacted-file registration while the
+    // compacted file itself remains on disk.
+    {
+        compaction_catalog catalog{location};
+        catalog.update_catalog_file(0, 0, {}, {});
+    }
+    ASSERT_TRUE(boost::filesystem::exists(compacted_path));
+
+    // Startup must fail fast because the catalog is inconsistent. Verify both that a
+    // limestone_exception is thrown and that its message is the intended one (so that an
+    // unrelated failure that happens to throw the same type is not mistaken for success).
+    // TODO: replace this placeholder with the actual message once the detection is implemented.
+    const std::string expected_message_substr = "compaction catalog is inconsistent";
+    try {
+        gen_datastore();
+        FAIL() << "expected a limestone_exception to be thrown, but nothing was thrown";
+    } catch (const limestone_exception& e) {
+        EXPECT_NE(std::string(e.what()).find(expected_message_substr), std::string::npos)
+            << "unexpected exception message: " << e.what();
+    } catch (const std::exception& e) {
+        FAIL() << "expected a limestone_exception, but a different exception was thrown: " << e.what();
+    }
+}
+
+}  // namespace limestone::testing

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -18,6 +18,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <map>
 #include <set>
 #include <sstream>
@@ -189,6 +190,66 @@ TEST_F(offline_compaction_test, detects_inconsistent_compaction_catalog_at_start
     } catch (const std::exception& e) {
         FAIL() << "expected a limestone_exception, but a different exception was thrown: " << e.what();
     }
+}
+
+// Offline compaction must preserve the max_blob_id high-water mark recorded in the
+// existing catalog, even though the freshly computed value (no blobs here) is lower.
+// Lowering it could lead to blob-id reuse.
+TEST_F(offline_compaction_test, offline_compaction_preserves_blob_id_high_water_mark) {
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "key1", "value1", {1, 0});  // no blob -> computed max_blob_id is 0
+    lc0_->end_session();
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // Simulate a high-water mark left by earlier blob allocations / online compactions.
+    {
+        compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+        catalog.update_catalog_file(catalog.get_max_epoch_id(), 9999, {}, {});
+    }
+
+    run_offline_compaction();
+
+    // The high-water mark must survive offline compaction (not lowered to the computed 0).
+    compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+    EXPECT_EQ(catalog.get_max_blob_id(), 9999);
+}
+
+// Offline compaction must recover the existing catalog from its backup when the main
+// catalog file is unreadable, and still preserve the high-water mark.
+TEST_F(offline_compaction_test, offline_compaction_recovers_catalog_from_backup) {
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "key1", "value1", {1, 0});
+    lc0_->end_session();
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    {
+        compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+        catalog.update_catalog_file(catalog.get_max_epoch_id(), 7777, {}, {});
+    }
+
+    // Leave the valid content only in the backup, then corrupt the main catalog file.
+    boost::filesystem::path dir{location};
+    boost::filesystem::path main_catalog = dir / compaction_catalog::get_catalog_filename();
+    boost::filesystem::path backup_catalog = dir / compaction_catalog::get_catalog_backup_filename();
+    boost::filesystem::copy_file(main_catalog, backup_catalog, boost::filesystem::copy_options::overwrite_existing);
+    {
+        std::ofstream ofs(main_catalog.string(), std::ios::trunc);
+        ofs << "GARBAGE";
+    }
+
+    run_offline_compaction();
+
+    // The catalog must have been recovered from the backup and the high-water mark kept.
+    compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
+    EXPECT_EQ(catalog.get_max_blob_id(), 7777);
 }
 
 }  // namespace limestone::testing

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -40,6 +40,10 @@ using namespace limestone::internal;
 // (datastore -> shutdown -> offline compaction -> restart) can be exercised.
 class offline_compaction_test : public compaction_test {
 public:
+    // Use a dedicated directory so this suite does not collide with compaction_test,
+    // which shares the same fixture base; ctest runs the two suites in parallel.
+    offline_compaction_test() { location = "/tmp/offline_compaction_test"; }
+
     // Path to the offline compaction utility (tglogutil), relative to the test
     // executable's working directory. This matches the convention used by
     // dblogutil_compaction_test.

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -42,7 +42,7 @@ class offline_compaction_test : public compaction_test {
 public:
     // Use a dedicated directory so this suite does not collide with compaction_test,
     // which shares the same fixture base; ctest runs the two suites in parallel.
-    offline_compaction_test() { location = "/tmp/offline_compaction_test"; }
+    offline_compaction_test() : compaction_test("/tmp/offline_compaction_test") {}
 
     // Path to the offline compaction utility (tglogutil), relative to the test
     // executable's working directory. This matches the convention used by

--- a/test/limestone/replication/log_channel_handler_test.cpp
+++ b/test/limestone/replication/log_channel_handler_test.cpp
@@ -37,7 +37,7 @@ class dummy_server {};
 
 class log_channel_handler_test : public ::testing::Test {
 protected:
-    static constexpr const char* base_location = "/tmp/replica_server_test";
+    static constexpr const char* base_location = "/tmp/log_channel_handler_test";
 
     void SetUp() override {
         boost::filesystem::remove_all(base_location);
@@ -689,7 +689,7 @@ TEST_F(log_channel_handler_test, handle_rdma_data_event_with_blob_entry_writes_b
     set_non_blocking(ctx.read_fd);
 
     // Build a sender-side datastore in a separate directory to create the blob file.
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};
@@ -751,7 +751,7 @@ TEST_F(log_channel_handler_test,
     ASSERT_GE(ctx.write_fd, 0);
     set_non_blocking(ctx.read_fd);
 
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};
@@ -816,7 +816,7 @@ TEST_F(log_channel_handler_test,
     ASSERT_GE(ctx.write_fd, 0);
     set_non_blocking(ctx.read_fd);
 
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};
@@ -896,7 +896,7 @@ TEST_F(log_channel_handler_test,
     ASSERT_GE(ctx.write_fd, 0);
     set_non_blocking(ctx.read_fd);
 
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};
@@ -963,7 +963,7 @@ TEST_F(log_channel_handler_test,
 
 TEST_F(log_channel_handler_test,
        rdma_replication_message_io_send_blob_with_empty_staged_buffer_sends_blob_only) {
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};
@@ -998,7 +998,7 @@ TEST_F(log_channel_handler_test,
 
 TEST_F(log_channel_handler_test,
        rdma_replication_message_io_send_blob_sends_remaining_data_in_later_writes) {
-    constexpr const char* sender_dir = "/tmp/replica_server_test_sender";
+    constexpr const char* sender_dir = "/tmp/log_channel_handler_test_sender";
     boost::filesystem::remove_all(sender_dir);
     boost::filesystem::create_directories(sender_dir);
     limestone::api::configuration sender_conf{};


### PR DESCRIPTION
## Related issue
https://github.com/project-tsurugi/tsurugi-issues/issues/1498

## Background / Problem
Offline compaction (`tglogutil compaction`) produced `pwal_0000.compacted` but did
not update the `compaction_catalog`.

When the `compaction_catalog` is not updated, snapshot generation at startup can
apply the condition for the case where no compacted WAL exists. In that case the
snapshot drops remove entries, so deleted records are not removed from the snapshot. Because the compacted file is loaded at startup based purely on its
presence on disk, deleted records are resurrected, which breaks index recovery and
can lead to a startup failure.

### Conditions to reproduce
The problem manifests on the second startup after an offline compaction when
both of the following hold:

1. No compaction (online or offline) is performed between the offline compaction
   and the second startup.
2. Between the first startup and the following shutdown, the DB is updated such that
   one or more remove entries are written to the WAL.

Remove entries are written to the WAL by any of the following operations on
data that existed at the time of the compaction:

- `DROP TABLE` of such a table
- `DROP INDEX` of such an index
- `DELETE` of such a record
- `TRUNCATE` of such a table
- An `UPDATE` that changes an index key of such a record
  (occurs for both primary keys and secondary indexes)

## Impact
This bug manifests in two ways:

### 1. Startup failure
Tsurugi fails to start. One concrete cause is: if a table was dropped by DDL and a
table/index with the same name was then re-created, startup fails due to duplicate
table metadata for the same table/index name.

### 2. Startup succeeds, but data is corrupted
Tsurugi starts successfully, but deleted tables/records are resurrected, leaving the
data inconsistent. Specifically:
1. A table dropped by DDL may be resurrected. The resurrected table may be
   inconsistent and is unusable.
2. A record deleted by DML may fail to be reflected (the deletion is lost).
3. For a table with a secondary index, resurrected deleted entries in the secondary
   index can make DML behave incorrectly. For example, after updating such a table
   and restarting Tsurugi, a `SELECT` whose `WHERE` clause matches a deleted
   secondary-index entry may match the wrong record.
4. If a table A with a sequence is dropped and another table B with a sequence is
   then created, table B may reference table A's sequence, causing DML on table B
   to behave incorrectly (e.g. `UNIQUE_CONSTRAINT_VIOLATION_EXCEPTION` on `INSERT`).

## Changes
- **Part 1 (`dblogutil.cpp`)**: Offline compaction now registers the compacted file
  in the `compaction_catalog` (max epoch id, max blob id, `pwal_0000.compacted`).
- **Part 2 (`datastore.cpp`)**: At startup, detect the inconsistency where
  `pwal_0000.compacted` exists on disk but is not registered in the catalog, and
  fail fast with `initialization_failure` instead of silently corrupting data.

## Tests
- `offline_compaction_test` (new)
  - `preserves_remove_entries_after_restart`: end-to-end test driving the real
    `tglogutil compaction` binary. Verifies the catalog registration and that a
    deleted record is not resurrected after restart (regression test for this issue).
  - `detects_inconsistent_compaction_catalog_at_startup`: verifies that startup of an
    inconsistent state fails with an exception (including its message).
- All tests pass (no regression).

## Workaround
- Use online compaction instead of offline compaction.

## Recovery procedure
1. If Tsurugi is running, stop it.
2. Run offline compaction (`tglogutil compaction`) against the stopped database.
   This consolidates all WAL contents — including remove entries — into the
   compacted file, restoring consistency between the compacted file and the pending
   remove entries.
3. Upgrade Tsurugi to a version that includes this PR.

If you do not perform step 3, follow the Workaround instead: do not use offline
compaction; use online compaction.

This procedure recovers from both states described under Impact: the startup failure
(case 1) and the corrupted-but-running state (case 2). Re-running the offline compaction
applies the pending remove entries into the compacted file, so the next startup no
longer resurrects deleted data.

However, it does not correct *secondary* damage. If the database was updated while in
the Impact case 2 state — that is, application writes were performed while the database
contained corrupted (resurrected) data — those writes may have depended on incorrect
data and may therefore be incorrect themselves. This procedure does not turn such incorrect data
into correct data; it only restores the consistency of the deletion/compaction state.
In that case, restore from a backup taken before the corruption occurred, or inspect
and correct the affected data manually at the application level.

## When the bug was introduced
- `733f19a` (2024-08-23) "Add LOG-0.6 compaction functionality": introduced the
  `compaction_catalog` mechanism, but offline compaction was never updated to write
  the catalog. This is the root cause.
- `477b405` (2024-10-21) "feat(performance): optimize startup time by eliminating
  unnecessary sorting": made snapshot generation drop remove entries when the
  compacted files recorded in `compaction_catalog` are empty. From this commit on,
  the offline
  compaction path (which leaves the catalog empty) actually triggers the reported
  data corruption.
