### PR TITLE
fix(compaction): preserve blob directory and manifest on offline compaction

### DIFF
--- a/src/limestone/dblogutil/dblogutil.cpp
+++ b/src/limestone/dblogutil/dblogutil.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <sys/stat.h>
+
 #include <iostream>
 #include <stdlib.h>  // NOLINT(*-deprecated-headers): <cstdlib> does not provide std::mkdtemp
 #include <glog/logging.h>
@@ -182,6 +184,24 @@ boost::filesystem::path make_backup_dir_next_to(const boost::filesystem::path& t
     return make_tmp_dir_next_to(target_dir, ".backup_XXXXXX");
 }
 
+/**
+ * @brief tests whether two existing directories reside on the same filesystem.
+ * @param a a path to an existing directory
+ * @param b a path to an existing directory
+ * @return true if both are on the same filesystem (same st_dev), false otherwise
+ */
+bool on_same_filesystem(boost::filesystem::path const& a, boost::filesystem::path const& b) {
+    struct stat sa {};
+    struct stat sb {};
+    if (::stat(a.c_str(), &sa) != 0) {
+        LOG_AND_THROW_IO_EXCEPTION("stat failed: " + a.string(), errno);
+    }
+    if (::stat(b.c_str(), &sb) != 0) {
+        LOG_AND_THROW_IO_EXCEPTION("stat failed: " + b.string(), errno);
+    }
+    return sa.st_dev == sb.st_dev;
+}
+
 // Carry over the existing compaction catalog (and its backup) from from_dir into the
 // work directory tmp, then register the freshly produced compacted file. tmp will
 // replace from_dir, so carrying over the catalog preserves the high-water marks
@@ -289,10 +309,9 @@ void copy_directory_recursively(
  * Without this step the blob data would be lost when from_dir is removed (or renamed away for
  * backup) and replaced by the working directory. When make_backup is requested the blob
  * directory is copied so that the backup keeps its own blob data; otherwise it is moved by
- * rename. The rename requires from_dir and tmp to be on the same filesystem; this holds for
- * the default working directory (created next to from_dir), and the final rename(tmp, from_dir)
- * in compaction() relies on the same condition, so a cross-filesystem working directory is
- * rejected here with a clear message rather than failing obscurely later.
+ * rename. The move requires from_dir and tmp to be on the same filesystem; compaction()
+ * already rejects a cross-filesystem working directory up front, so the rename below is a
+ * defense-in-depth check that should not normally fail.
  * @param from_dir the original log directory
  * @param tmp the working directory the compacted log is assembled in
  * @param make_backup true if from_dir is kept as a backup, so blob data must remain in it
@@ -355,6 +374,19 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
         tmp = make_work_dir_next_to(from_dir);
     }
     std::cout << "working-directory: " << tmp << std::endl;
+
+    // The working directory must be on the same filesystem as the dblogdir. Compaction
+    // carries the log directory contents over into tmp and finally renames tmp onto
+    // from_dir; both the blob move and that final rename fail across filesystems. With
+    // --make_backup this would be especially harmful: from_dir is first renamed away to
+    // the backup, and only then does rename(tmp, from_dir) fail, leaving no from_dir
+    // restored. Reject a cross-filesystem working directory up front, before any
+    // destructive step, regardless of --make_backup.
+    if (!on_same_filesystem(from_dir, tmp)) {
+        LOG(ERROR) << "working directory must be on the same filesystem as the dblogdir: "
+                   << "dblogdir=" << from_dir << ", working-directory=" << tmp;
+        log_and_exit(64);
+    }
 
     if (!FLAGS_force) {
         // prompt

--- a/src/limestone/dblogutil/dblogutil.cpp
+++ b/src/limestone/dblogutil/dblogutil.cpp
@@ -232,6 +232,99 @@ void carry_over_and_update_compaction_catalog(boost::filesystem::path const& fro
     catalog.update_catalog_file(ld_epoch, max_blob_id, {compacted_file}, {});
 }
 
+/**
+ * @brief copies the manifest file from the original log directory to the working directory.
+ *
+ * setup_initial_logdir() creates a brand-new manifest in the working directory, which would
+ * replace the original instance_uuid with a freshly generated one. Overwrite it with the
+ * original manifest so that the instance identity survives offline compaction. The manifest
+ * in from_dir is guaranteed to exist and to be migrated to the current format version because
+ * main() calls manifest::acquire_lock() and check_and_migrate_logdir_format() beforehand.
+ * @param from_dir the original log directory
+ * @param tmp the working directory the compacted log is assembled in
+ */
+void carry_over_manifest_file(
+        boost::filesystem::path const& from_dir, boost::filesystem::path const& tmp) {
+    boost::filesystem::path src = from_dir / std::string(manifest::file_name);
+    boost::system::error_code ec;
+    bool present = boost::filesystem::exists(src, ec);
+    if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+        LOG_AND_THROW_IO_EXCEPTION(
+                "failed to check existence of manifest file: " + src.string(), ec);
+    }
+    if (!present) {
+        // must not happen: main() has already acquired the lock on this file
+        LOG_AND_THROW_EXCEPTION("manifest file not found in dblogdir: " + src.string());
+    }
+    boost::filesystem::copy_file(src, tmp / std::string(manifest::file_name),
+                                 boost::filesystem::copy_options::overwrite_existing, ec);
+    if (ec) {
+        LOG_AND_THROW_IO_EXCEPTION("failed to copy manifest file: " + src.string(), ec);
+    }
+}
+
+/**
+ * @brief recursively copies a directory tree.
+ * @param src the source directory (must exist)
+ * @param dst the destination directory (created by this function)
+ */
+void copy_directory_recursively(
+        boost::filesystem::path const& src, boost::filesystem::path const& dst) {
+    boost::system::error_code ec;
+    boost::filesystem::create_directories(dst, ec);
+    if (ec) {
+        LOG_AND_THROW_IO_EXCEPTION("failed to create directory: " + dst.string(), ec);
+    }
+    boost::filesystem::copy(src, dst,
+            boost::filesystem::copy_options::recursive |
+            boost::filesystem::copy_options::overwrite_existing, ec);
+    if (ec) {
+        LOG_AND_THROW_IO_EXCEPTION("failed to copy directory: " + src.string(), ec);
+    }
+}
+
+/**
+ * @brief carries the blob directory over from the original log directory to the working directory.
+ *
+ * Without this step the blob data would be lost when from_dir is removed (or renamed away for
+ * backup) and replaced by the working directory. When make_backup is requested the blob
+ * directory is copied so that the backup keeps its own blob data; otherwise it is moved by
+ * rename. The rename requires from_dir and tmp to be on the same filesystem; this holds for
+ * the default working directory (created next to from_dir), and the final rename(tmp, from_dir)
+ * in compaction() relies on the same condition, so a cross-filesystem working directory is
+ * rejected here with a clear message rather than failing obscurely later.
+ * @param from_dir the original log directory
+ * @param tmp the working directory the compacted log is assembled in
+ * @param make_backup true if from_dir is kept as a backup, so blob data must remain in it
+ */
+void carry_over_blob_directory(
+        boost::filesystem::path const& from_dir, boost::filesystem::path const& tmp,
+        bool make_backup) {
+    boost::filesystem::path src = from_dir / "blob";
+    boost::system::error_code ec;
+    bool present = boost::filesystem::exists(src, ec);
+    if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+        LOG_AND_THROW_IO_EXCEPTION(
+                "failed to check existence of blob directory: " + src.string(), ec);
+    }
+    if (!present) {
+        return;  // no blob data; nothing to carry over
+    }
+    boost::filesystem::path dst = tmp / "blob";
+    if (make_backup) {
+        VLOG_LP(log_info) << "copying blob directory " << src << " to " << dst;
+        copy_directory_recursively(src, dst);
+        return;
+    }
+    VLOG_LP(log_info) << "moving blob directory " << src << " to " << dst;
+    boost::filesystem::rename(src, dst, ec);
+    if (ec) {
+        LOG_AND_THROW_IO_EXCEPTION(
+                "failed to move blob directory (the working directory must be on the same "
+                "filesystem as the dblogdir): " + src.string(), ec);
+    }
+}
+
 void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
     epoch_id_type ld_epoch{};
     if (epoch.has_value()) {
@@ -276,6 +369,10 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
 
     setup_initial_logdir(tmp);
 
+    // Carry over the original manifest so that the instance_uuid is preserved
+    // (see the offline compaction blob-loss issue).
+    carry_over_manifest_file(from_dir, tmp);
+
     VLOG_LP(log_info) << "making compact pwal file to " << tmp;
     compaction_options options{from_dir, tmp, FLAGS_thread_num};
     blob_id_type max_blob_id = create_compact_pwal_and_get_max_blob_id(options);
@@ -310,6 +407,10 @@ void compaction(dblog_scan &ds, std::optional<epoch_id_type> epoch) {
         boost::filesystem::remove_all(tmp);
         return;
     }
+
+    // Carry over the blob data after the dry-run check so that a dry run never
+    // touches from_dir, and right before the directory swap below.
+    carry_over_blob_directory(from_dir, tmp, FLAGS_make_backup);
 
     if (FLAGS_make_backup) {
         auto bkdir = make_backup_dir_next_to(from_dir);

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>  // NOLINT(*-deprecated-headers): <cstdlib> does not provide ::mkdtemp
+#include <sys/stat.h>
+
 #include <array>
 #include <cerrno>
 #include <cstdio>
@@ -69,13 +72,113 @@ public:
     }
 
     // Run offline compaction on the test location via the tglogutil binary.
-    void run_offline_compaction() {
+    // Extra command line options (e.g. "--make_backup") can be passed through.
+    void run_offline_compaction(std::string const& extra_options = "") {
         std::string out;
-        std::string command = std::string(util_command) + " compaction --force " + std::string(location) + " 2>&1";
+        std::string command = std::string(util_command) + " compaction --force " +
+            (extra_options.empty() ? "" : extra_options + " ") + std::string(location) + " 2>&1";
         int rc = invoke(command, out);
         ASSERT_EQ(rc, 0) << "invoke failed: " << out;
         ASSERT_TRUE(out.find("compaction was successfully completed: ") != std::string::npos)
             << "tglogutil output:\n" << out;
+    }
+
+    // Read a whole file into a string (byte-exact, for content comparison).
+    static std::string read_file(boost::filesystem::path const& path) {
+        std::ifstream ifs(path.string(), std::ios::binary);
+        std::ostringstream ss;
+        ss << ifs.rdbuf();
+        return ss.str();
+    }
+
+    // Enumerate sibling directories of the test location whose name is
+    // "<location><marker>XXXXXX" (tglogutil creates ".work_" / ".backup_" directories
+    // next to the target directory).
+    std::vector<boost::filesystem::path> find_sibling_dirs(std::string const& marker) const {
+        std::vector<boost::filesystem::path> dirs;
+        boost::filesystem::path base{location};
+        std::string prefix = base.filename().string() + marker;
+        for (boost::filesystem::directory_iterator it{base.parent_path()}, end; it != end; ++it) {
+            if (boost::filesystem::is_directory(it->status()) &&
+                starts_with(it->path().filename().string(), prefix)) {
+                dirs.push_back(it->path());
+            }
+        }
+        return dirs;
+    }
+
+    // Enumerate backup directories created by "tglogutil compaction --make_backup".
+    std::vector<boost::filesystem::path> find_backup_dirs() const {
+        return find_sibling_dirs(".backup_");
+    }
+
+    // Remove leftover backup directories (from this run or an earlier aborted one).
+    void remove_backup_dirs() const {
+        for (boost::filesystem::path const& dir : find_backup_dirs()) {
+            boost::filesystem::remove_all(dir);
+        }
+    }
+
+    // Remove leftover working directories that a failed compaction run leaves behind.
+    void remove_work_dirs() const {
+        for (boost::filesystem::path const& dir : find_sibling_dirs(".work_")) {
+            boost::filesystem::remove_all(dir);
+        }
+    }
+
+    // Collect the set of top-level entry names (files and directories) directly under dir.
+    static std::set<std::string> list_top_level_entries(boost::filesystem::path const& dir) {
+        std::set<std::string> names;
+        for (boost::filesystem::directory_iterator it{dir}, end; it != end; ++it) {
+            names.insert(it->path().filename().string());
+        }
+        return names;
+    }
+
+    // Decide whether a top-level entry is expected to disappear during compaction.
+    // This is an explicit allow-list of the entries compaction is known to consume:
+    // it merges the pwal files into pwal_0000.compacted, rewrites the epoch file, and
+    // drops derived/temporary artifacts. Anything not listed here - including files a
+    // future change might add to the log directory - is treated as "must be preserved",
+    // so that a compaction that fails to handle such a new file is detected as a lost file.
+    bool is_expected_to_disappear(std::string const& name) const {
+        // rotated epoch files (epoch.<ts>.<id>): the durable epoch is re-emitted into "epoch"
+        if (starts_with(name, "epoch.")) {
+            return true;
+        }
+        // the temporary epoch file
+        if (name == ".epoch.tmp") {
+            return true;
+        }
+        // Derived / control-only directories that the datastore recreates on startup:
+        // - compaction_temp: online-compaction working directory
+        // - data: the snapshot directory
+        // - ctrl: online-compaction control directory (holds the start_compaction trigger)
+        if (name == compaction_catalog::get_compaction_temp_dirname() || name == "data"
+            || name == "ctrl") {
+            return true;
+        }
+        // pwal files other than the compacted ones are merged into pwal_0000.compacted
+        if (starts_with(name, "pwal_")) {
+            return name != compacted_filename && name != (compacted_filename + ".prev");
+        }
+        return false;
+    }
+
+    // Take a recursive snapshot of dir: a map from the path relative to dir to the file
+    // content. Directories are recorded with an empty content so that empty directories
+    // are compared as well.
+    static std::map<std::string, std::string> snapshot_tree(boost::filesystem::path const& dir) {
+        std::map<std::string, std::string> tree;
+        for (boost::filesystem::recursive_directory_iterator it{dir}, end; it != end; ++it) {
+            std::string rel = boost::filesystem::relative(it->path(), dir).string();
+            if (boost::filesystem::is_directory(it->status())) {
+                tree.emplace(rel, std::string{});
+            } else {
+                tree.emplace(rel, read_file(it->path()));
+            }
+        }
+        return tree;
     }
 };
 
@@ -250,6 +353,262 @@ TEST_F(offline_compaction_test, offline_compaction_recovers_catalog_from_backup)
     // The catalog must have been recovered from the backup and the high-water mark kept.
     compaction_catalog catalog = compaction_catalog::from_catalog_file(location);
     EXPECT_EQ(catalog.get_max_blob_id(), 7777);
+}
+
+// Offline compaction must not lose the blob data: the blob directory has to be carried
+// over from the original log directory to the compacted one. With the bug, the whole
+// blob directory was deleted together with the original log directory.
+TEST_F(offline_compaction_test, offline_compaction_preserves_blob_files) {
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->end_session();
+    boost::filesystem::path blob_path = create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    ASSERT_TRUE(boost::filesystem::exists(blob_path));
+
+    run_offline_compaction();
+
+    // The blob file must physically survive offline compaction (default mode: moved).
+    EXPECT_TRUE(boost::filesystem::exists(blob_path));
+
+    // The datastore must restart and still see the blob-referencing entry and the blob file.
+    gen_datastore();
+    std::unique_ptr<snapshot> snapshot = datastore_->get_snapshot();
+    std::unique_ptr<cursor> cursor = snapshot->get_cursor();
+    std::map<std::string, std::string> kv;
+    while (cursor->next()) {
+        std::string key;
+        std::string value;
+        cursor->key(key);
+        cursor->value(value);
+        kv.emplace(key, value);
+    }
+    ASSERT_EQ(kv.count("blob_key"), 1U);
+    EXPECT_EQ(kv["blob_key"], "blob_value");
+    EXPECT_TRUE(boost::filesystem::exists(blob_path));
+}
+
+// Offline compaction must keep the original manifest file so that the instance_uuid
+// and the persistent format version survive. With the bug, a brand-new manifest with
+// a freshly generated instance_uuid replaced the original one.
+TEST_F(offline_compaction_test, offline_compaction_preserves_manifest_file) {
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "key1", "value1", {1, 0});
+    lc0_->end_session();
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    std::string manifest_before = read_file(manifest_path);
+    ASSERT_FALSE(manifest_before.empty());
+    ASSERT_NE(manifest_before.find("instance_uuid"), std::string::npos);
+
+    run_offline_compaction();
+
+    // The manifest must be carried over byte-exact (same instance_uuid, same versions).
+    std::string manifest_after = read_file(manifest_path);
+    EXPECT_EQ(manifest_after, manifest_before);
+}
+
+// With --make_backup, the blob directory must be copied (not moved) so that both the
+// compacted log directory and the backup directory keep the blob data.
+TEST_F(offline_compaction_test, offline_compaction_with_backup_copies_blob_directory) {
+    remove_backup_dirs();  // clean up leftovers from an earlier aborted run
+
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->end_session();
+    boost::filesystem::path blob_path = create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    boost::filesystem::path blob_relative = boost::filesystem::relative(blob_path, location);
+
+    run_offline_compaction("--make_backup");
+
+    // The compacted log directory must keep the blob data.
+    EXPECT_TRUE(boost::filesystem::exists(blob_path));
+
+    // The backup directory must also keep its own copy of the blob data.
+    std::vector<boost::filesystem::path> backup_dirs = find_backup_dirs();
+    ASSERT_EQ(backup_dirs.size(), 1U);
+    EXPECT_TRUE(boost::filesystem::exists(backup_dirs[0] / blob_relative));
+
+    remove_backup_dirs();
+}
+
+// Offline compaction must not silently drop any file it is not explicitly expected to
+// consume. The purpose of this test is to detect the case where a future change adds a
+// new file to the log directory and compaction is not updated to carry it over: any
+// top-level entry present before compaction that is not on the allow-list of consumed
+// entries (see is_expected_to_disappear) must still be present afterwards. This is
+// exactly the class of bug that lost the blob directory.
+TEST_F(offline_compaction_test, offline_compaction_does_not_drop_unexpected_files) {
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->add_entry(1, "plain_key", "plain_value", {1, 1});
+    lc0_->end_session();
+    create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    std::set<std::string> before = list_top_level_entries(location);
+    // The directory must contain the files whose preservation we care about.
+    ASSERT_NE(before.count(std::string(manifest::file_name)), 0U);
+    ASSERT_NE(before.count(compaction_catalog::get_catalog_filename()), 0U);
+    ASSERT_NE(before.count("blob"), 0U);
+
+    run_offline_compaction();
+
+    std::set<std::string> after = list_top_level_entries(location);
+    for (std::string const& name : before) {
+        if (is_expected_to_disappear(name)) {
+            continue;
+        }
+        EXPECT_NE(after.count(name), 0U)
+            << "unexpected file lost during offline compaction: " << name;
+    }
+}
+
+// With --make_backup, the backup directory must be a byte-exact copy of the log directory
+// as it was right before compaction: same set of files, same contents. This ensures the
+// backup is a faithful, fully recoverable image of the pre-compaction state.
+TEST_F(offline_compaction_test, offline_compaction_backup_matches_pre_compaction_state) {
+    remove_backup_dirs();  // clean up leftovers from an earlier aborted run
+
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->add_entry(1, "plain_key", "plain_value", {1, 1});
+    lc0_->end_session();
+    create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // Snapshot the whole log directory right before compaction.
+    std::map<std::string, std::string> before = snapshot_tree(location);
+
+    run_offline_compaction("--make_backup");
+
+    std::vector<boost::filesystem::path> backup_dirs = find_backup_dirs();
+    ASSERT_EQ(backup_dirs.size(), 1U);
+
+    // The backup must be identical to the pre-compaction directory, file for file.
+    std::map<std::string, std::string> backup = snapshot_tree(backup_dirs[0]);
+    EXPECT_EQ(backup, before);
+
+    remove_backup_dirs();
+}
+
+// When --working_dir points to a different filesystem, moving the blob directory by
+// rename cannot work (EXDEV), and neither can the final rename(tmp, from_dir); compaction
+// must fail fast with a clear message and leave the original log directory untouched.
+TEST_F(offline_compaction_test, offline_compaction_fails_when_working_dir_is_on_different_filesystem) {
+    if (!boost::filesystem::exists("/dev/shm")) {
+        GTEST_SKIP() << "/dev/shm is not available on this system";
+    }
+
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->end_session();
+    boost::filesystem::path blob_path = create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // Prepare a working directory on another filesystem (tmpfs).
+    std::string wd_template = "/dev/shm/offline_compaction_wd_XXXXXX";
+    ASSERT_NE(::mkdtemp(wd_template.data()), nullptr) << strerror(errno);
+    boost::filesystem::path working_dir{wd_template};
+
+    // Skip when the test location happens to live on the same filesystem as /dev/shm
+    // (e.g. /tmp mounted on the same tmpfs); rename would then succeed and the error
+    // path under test would not be reachable.
+    struct stat st_location {};
+    struct stat st_working_dir {};
+    ASSERT_EQ(::stat(location, &st_location), 0) << strerror(errno);
+    ASSERT_EQ(::stat(working_dir.c_str(), &st_working_dir), 0) << strerror(errno);
+    if (st_location.st_dev == st_working_dir.st_dev) {
+        boost::filesystem::remove_all(working_dir);
+        GTEST_SKIP() << "test location and /dev/shm are on the same filesystem";
+    }
+
+    std::string out;
+    std::string command = std::string(util_command) + " compaction --force --working_dir=" +
+        working_dir.string() + " " + std::string(location) + " 2>&1";
+    int rc = invoke(command, out);
+    EXPECT_NE(rc, 0) << "compaction should fail on a cross-filesystem working directory";
+    EXPECT_NE(out.find("failed to move blob directory"), std::string::npos)
+        << "tglogutil output:\n" << out;
+
+    // The failure must leave the original log directory untouched.
+    EXPECT_TRUE(boost::filesystem::exists(blob_path));
+
+    boost::filesystem::remove_all(working_dir);
+}
+
+// When the blob directory contains a broken entry that cannot be copied, the backup-mode
+// copy of the blob directory must fail with a clear message and leave the original log
+// directory untouched. A dangling symlink is used to force the failure: boost::filesystem
+// follows it and fails with ENOENT regardless of the caller's privileges, so this exercises
+// the copy-failure path even when the test runs as root (as it does in CI).
+TEST_F(offline_compaction_test, offline_compaction_backup_fails_when_blob_directory_copy_fails) {
+    remove_backup_dirs();
+    remove_work_dirs();
+
+    gen_datastore();
+    datastore_->switch_epoch(1);
+    lc0_->begin_session();
+    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+    lc0_->end_session();
+    boost::filesystem::path blob_path = create_dummy_blob_files(1001);
+    datastore_->set_next_blob_id(1002);
+    datastore_->switch_epoch(2);
+    datastore_->shutdown();
+    datastore_ = nullptr;
+
+    // Place a dangling symlink inside the blob directory so that the recursive copy fails
+    // when it tries to follow it. This is independent of file permissions, so it also
+    // reproduces the failure when running as root.
+    boost::filesystem::path dangling = blob_path.parent_path() / "dangling.blob";
+    boost::filesystem::create_symlink("/nonexistent/target", dangling);
+
+    std::string out;
+    std::string command = std::string(util_command) + " compaction --force --make_backup " +
+        std::string(location) + " 2>&1";
+    int rc = invoke(command, out);
+    EXPECT_NE(rc, 0) << "compaction should fail when a blob entry cannot be copied";
+    EXPECT_NE(out.find("failed to copy directory"), std::string::npos)
+        << "tglogutil output:\n" << out;
+
+    // The copy failure happens before the directory swap, so the original log directory
+    // must be fully intact and no backup directory must have been created.
+    EXPECT_TRUE(boost::filesystem::exists(blob_path));
+    EXPECT_TRUE(find_backup_dirs().empty());
+
+    remove_work_dirs();
 }
 
 }  // namespace limestone::testing

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -126,6 +126,64 @@ public:
         }
     }
 
+    // Shared driver for the cross-filesystem working-directory tests. Prepares a log
+    // directory with blob data, then runs offline compaction with --working_dir on a
+    // different filesystem (tmpfs under /dev/shm), optionally with --make_backup.
+    // Compaction must be rejected up front (before any destructive step) and must leave the
+    // original log directory fully intact. Skips when /dev/shm is unavailable or happens to
+    // be on the same filesystem as the location.
+    void run_cross_filesystem_working_dir_case(bool make_backup) {
+        if (!boost::filesystem::exists("/dev/shm")) {
+            GTEST_SKIP() << "/dev/shm is not available on this system";
+        }
+
+        gen_datastore();
+        datastore_->switch_epoch(1);
+        lc0_->begin_session();
+        lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
+        lc0_->end_session();
+        create_dummy_blob_files(1001);
+        datastore_->set_next_blob_id(1002);
+        datastore_->switch_epoch(2);
+        datastore_->shutdown();
+        datastore_ = nullptr;
+
+        std::map<std::string, std::string> before = snapshot_tree(location);
+
+        // Prepare a working directory on another filesystem (tmpfs).
+        std::string wd_template = "/dev/shm/offline_compaction_wd_XXXXXX";
+        ASSERT_NE(::mkdtemp(wd_template.data()), nullptr) << strerror(errno);
+        boost::filesystem::path working_dir{wd_template};
+
+        // Skip when the test location happens to live on the same filesystem as /dev/shm
+        // (e.g. /tmp mounted on the same tmpfs); the cross-filesystem path is unreachable.
+        struct stat st_location {};
+        struct stat st_working_dir {};
+        ASSERT_EQ(::stat(location, &st_location), 0) << strerror(errno);
+        ASSERT_EQ(::stat(working_dir.c_str(), &st_working_dir), 0) << strerror(errno);
+        if (st_location.st_dev == st_working_dir.st_dev) {
+            boost::filesystem::remove_all(working_dir);
+            GTEST_SKIP() << "test location and /dev/shm are on the same filesystem";
+        }
+
+        std::string out;
+        std::string command = std::string(util_command) + " compaction --force" +
+            (make_backup ? " --make_backup" : "") + " --working_dir=" +
+            working_dir.string() + " " + std::string(location) + " 2>&1";
+        int rc = invoke(command, out);
+        EXPECT_NE(rc, 0) << "compaction should fail on a cross-filesystem working directory";
+        EXPECT_NE(out.find("working directory must be on the same filesystem as the dblogdir"),
+                  std::string::npos)
+            << "tglogutil output:\n" << out;
+
+        // The upfront rejection must leave the original log directory fully intact, and no
+        // backup directory must have been created.
+        EXPECT_EQ(snapshot_tree(location), before);
+        EXPECT_TRUE(find_backup_dirs().empty());
+
+        boost::filesystem::remove_all(working_dir);
+    }
+
     // Collect the set of top-level entry names (files and directories) directly under dir.
     static std::set<std::string> list_top_level_entries(boost::filesystem::path const& dir) {
         std::set<std::string> names;
@@ -519,58 +577,16 @@ TEST_F(offline_compaction_test, offline_compaction_backup_matches_pre_compaction
     remove_backup_dirs();
 }
 
-// When --working_dir points to a different filesystem, moving the blob directory by
-// rename cannot work (EXDEV), and neither can the final rename(tmp, from_dir); compaction
-// must fail fast with a clear message and leave the original log directory untouched.
+// A cross-filesystem --working_dir must be rejected up front (default / move mode).
 TEST_F(offline_compaction_test, offline_compaction_fails_when_working_dir_is_on_different_filesystem) {
-    if (!boost::filesystem::exists("/dev/shm")) {
-        GTEST_SKIP() << "/dev/shm is not available on this system";
-    }
+    run_cross_filesystem_working_dir_case(/*make_backup=*/false);
+}
 
-    gen_datastore();
-    datastore_->switch_epoch(1);
-    lc0_->begin_session();
-    lc0_->add_entry(1, "blob_key", "blob_value", {1, 0}, {1001});
-    lc0_->end_session();
-    boost::filesystem::path blob_path = create_dummy_blob_files(1001);
-    datastore_->set_next_blob_id(1002);
-    datastore_->switch_epoch(2);
-    datastore_->shutdown();
-    datastore_ = nullptr;
-
-    // Prepare a working directory on another filesystem (tmpfs).
-    std::string wd_template = "/dev/shm/offline_compaction_wd_XXXXXX";
-    ASSERT_NE(::mkdtemp(wd_template.data()), nullptr) << strerror(errno);
-    boost::filesystem::path working_dir{wd_template};
-
-    // Skip when the test location happens to live on the same filesystem as /dev/shm
-    // (e.g. /tmp mounted on the same tmpfs); rename would then succeed and the error
-    // path under test would not be reachable.
-    struct stat st_location {};
-    struct stat st_working_dir {};
-    ASSERT_EQ(::stat(location, &st_location), 0) << strerror(errno);
-    ASSERT_EQ(::stat(working_dir.c_str(), &st_working_dir), 0) << strerror(errno);
-    if (st_location.st_dev == st_working_dir.st_dev) {
-        boost::filesystem::remove_all(working_dir);
-        GTEST_SKIP() << "test location and /dev/shm are on the same filesystem";
-    }
-
-    std::string out;
-    std::string command = std::string(util_command) + " compaction --force --working_dir=" +
-        working_dir.string() + " " + std::string(location) + " 2>&1";
-    int rc = invoke(command, out);
-    // Compaction must fail: a cross-filesystem working directory cannot work, because both
-    // the carry-over of the log directory contents and the final rename(tmp, from_dir)
-    // require the same filesystem. We only assert the failure and that the original log
-    // directory is left intact, not a specific message: which cross-device operation trips
-    // first (carrying over the manifest, moving the blob directory, or the final rename)
-    // depends on the platform's copy/rename behavior.
-    EXPECT_NE(rc, 0) << "compaction should fail on a cross-filesystem working directory";
-
-    // The failure must leave the original log directory untouched.
-    EXPECT_TRUE(boost::filesystem::exists(blob_path));
-
-    boost::filesystem::remove_all(working_dir);
+// A cross-filesystem --working_dir must be rejected up front in --make_backup mode too.
+// Otherwise from_dir would be renamed away to the backup and the final rename(tmp, from_dir)
+// would fail, leaving no from_dir restored.
+TEST_F(offline_compaction_test, offline_compaction_with_backup_fails_when_working_dir_is_on_different_filesystem) {
+    run_cross_filesystem_working_dir_case(/*make_backup=*/true);
 }
 
 // When the blob directory contains a broken entry that cannot be copied, the backup-mode

--- a/test/limestone/compaction/offline_compaction_test.cpp
+++ b/test/limestone/compaction/offline_compaction_test.cpp
@@ -559,9 +559,13 @@ TEST_F(offline_compaction_test, offline_compaction_fails_when_working_dir_is_on_
     std::string command = std::string(util_command) + " compaction --force --working_dir=" +
         working_dir.string() + " " + std::string(location) + " 2>&1";
     int rc = invoke(command, out);
+    // Compaction must fail: a cross-filesystem working directory cannot work, because both
+    // the carry-over of the log directory contents and the final rename(tmp, from_dir)
+    // require the same filesystem. We only assert the failure and that the original log
+    // directory is left intact, not a specific message: which cross-device operation trips
+    // first (carrying over the manifest, moving the blob directory, or the final rename)
+    // depends on the platform's copy/rename behavior.
     EXPECT_NE(rc, 0) << "compaction should fail on a cross-filesystem working directory";
-    EXPECT_NE(out.find("failed to move blob directory"), std::string::npos)
-        << "tglogutil output:\n" << out;
 
     // The failure must leave the original log directory untouched.
     EXPECT_TRUE(boost::filesystem::exists(blob_path));


### PR DESCRIPTION
## Summary

Fixes a bug where running offline compaction (`tglogutil compaction`) loses blob
data. It also fixes a manifest-overwrite problem that stems from the same root
cause: offline compaction assembles a working directory and then replaces the
original log directory wholesale, but the carry-over of some entries was missing.

Related issue: https://github.com/project-tsurugi/tsurugi-issues/issues/1526

> **Note**: PR #137 is a follow-up to this PR. It removes the `--working_dir`
> option referenced below entirely, drops `--epoch` from the `compaction`
> subcommand, and fixes the tglogutil documentation. Readers coming from the
> release notes should read both PRs together.

## Root cause

Offline compaction builds the compacted result in a working directory `tmp` and,
at the end, removes the original log directory (or renames it away for backup) and
replaces it with `tmp`. Anything that is not explicitly created in `tmp` is
therefore lost.

- **Blob loss**: there was no step to carry `from_dir/blob/` over to `tmp`, so the
  blob files were deleted together with the original directory.
- **Manifest overwrite**: `setup_initial_logdir` creates a brand-new manifest in
  `tmp`, so the original `instance_uuid` was replaced with a freshly generated one
  (and the persistent format version was reset to the latest).

Online compaction does not hit this because it does not replace the directory
wholesale; it only swaps in the compacted file and leaves `blob/` and the manifest
in place.

## Changes

- Carry the blob directory over from `from_dir` to `tmp`.
  - Default: moved by `rename`.
  - With `--make_backup`: copied, so the backup keeps its own blob data.
- Reject a cross-filesystem `--working_dir` up front with a clear error message,
  in both the default and `--make_backup` modes, instead of failing obscurely
  later at the final `rename(tmp, from_dir)` (the rename requires `from_dir` and
  `tmp` to be on the same filesystem).
  - Review follow-up: the initial version of this PR rejected this only on the
    default (move) path; in `--make_backup` mode the blob copy succeeds across
    filesystems and the run failed later with `EXDEV`, after the original
    directory had already been renamed away. The check is now performed up front
    regardless of `--make_backup`, with regression tests for both modes.
- Carry the original manifest over to `tmp` so that the `instance_uuid` and the
  persistent format version survive offline compaction. This is safe because
  `main()` runs `manifest::acquire_lock()` and `check_and_migrate_logdir_format()`
  beforehand, so the manifest in `from_dir` is guaranteed to exist and to already be
  migrated to the current format version.
- Add regression tests covering:
  - blob files and the manifest surviving compaction (default move path);
  - blob directory being copied (not moved) in `--make_backup` mode;
  - no unexpected top-level entry being dropped (guards against a future file added
    to the log directory being lost the way the blob directory was);
  - the backup being a byte-exact image of the pre-compaction directory;
  - the cross-filesystem working-directory failure path (default and
    `--make_backup` modes);
  - the blob-directory copy-failure path.
